### PR TITLE
Async CLOPS dispatch/polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,31 @@ Otherwise, if you are running on a simulator, once you have invoked the `poetry
 shell` command as described above, run:
 
 ```
-python metriq_gym/hardware/qv_clops_qiskit.py
+python metriq_gym/dispatch_qv.py
 ```
+for Quantum Volume benchmarks or
+```
+python metriq_gym/dispatch_clops.py
+```
+for CLOPS.
 
-Doing so will yield output similar to the following:
+Doing so will yield output similar to the following (if running on a simulator):
 
 ```
 2024-10-08 14:38:43,117 - INFO - Aggregated results over 8 trials: {'qubits': 16, 'seconds': 0.7648332118988037, 'sim_seconds': 1.2858296614140272, 'hog_prob': 0.4239501953125, 'pass': False, 'p-value': np.float64(0.0), 'clops': 10967891.913550833, 'sim_clops': 6523887.457048584}
 {'qubits': 16, 'seconds': 0.7648332118988037, 'sim_seconds': 1.2858296614140272, 'hog_prob': 0.4239501953125, 'pass': False, 'p-value': np.float64(0.0), 'clops': 10967891.913550833, 'sim_clops': 6523887.457048584}
 ```
+
+If running on quantum cloud hardware, the job will be added to a polling queue. The status of the queue can be checked with
+```
+python metriq_gym/poll_qv.py
+```
+or
+```
+python metriq_gym/poll_clops.py
+```
+at which point, any completed jobs results will be printed.
+
 
 If you wish to specify more command line arguments and run on hardware (assuming
 that you have obtained your IBM token) you can run:

--- a/metriq_gym/dispatch_clops.py
+++ b/metriq_gym/dispatch_clops.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import sys
 
 from dataclasses import asdict
 
@@ -44,16 +45,18 @@ def main():
         interval = result.time_taken,
         sim_interval = 0
     )
-    result = json.dumps(asdict(result))
+
+    # Convert dataclass to string (JSON)
+    result_json = json.dumps(asdict(result))
+
     with open(args.jobs_file, "a") as file:
-        # Out to file
         file.write(str(result_json) + os.linesep)
 
-    logging.info(str(result_dict))
-    print(str(result_dict))
+    logging.info(str(result_json))
+    print(str(result_json))
 
     return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/metriq_gym/dispatch_clops.py
+++ b/metriq_gym/dispatch_clops.py
@@ -1,0 +1,59 @@
+"""Dispatch a CLOPS job with CLI parameters to Qiskit and wait for result."""
+import json
+import logging
+import os
+
+from dataclasses import asdict
+
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+from metriq_gym.parse import parse_arguments
+from metriq_gym.bench import BenchJobResult, BenchJobType, BenchProvider
+from metriq_gym.hardware.clops_benchmark import clops_benchmark
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+def main():
+    args = parse_arguments()
+
+    if not args.token:
+        raise ValueError("CLOPS benchmark requires an IBMQ token!")
+
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
+
+    logging.info(f"Dispatching CLOPS job with n={args.n}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
+
+    clops = clops_benchmark(
+        QiskitRuntimeService(),
+        args.backend,
+        width = args.n,
+        layers = args.n,
+        shots = args.shots
+    )
+    
+    result = BenchJobResult(
+        id = clops.job.job_id(),
+        provider = BenchProvider.IBMQ,
+        job_type = BenchJobType.CLOPS,
+        qubits = clops.job_attributes.width,
+        shots = clops.job_attributes.shots,
+        depth = clops.job_attributes.layers,
+        ideal_probs = [],
+        counts = [],
+        interval = result.time_taken,
+        sim_interval = 0
+    )
+    result = json.dumps(asdict(result))
+    with open(args.jobs_file, "a") as file:
+        # Out to file
+        file.write(str(result_json) + os.linesep)
+
+    logging.info(str(result_dict))
+    print(str(result_dict))
+
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/metriq_gym/dispatch_qv.py
+++ b/metriq_gym/dispatch_qv.py
@@ -31,11 +31,12 @@ def main():
 
         return 0
 
-    logging.info(f"Dispatched {args.trials} jobs")
+    logging.info(f"Dispatched {args.trials} trials in 1 job.")
+
+    # Convert dataclass to string (JSON)
+    result_json = json.dumps(asdict(result))
 
     with open(args.jobs_file, "a") as file:
-        # Convert dataclass to string (JSON)
-        result_json = json.dumps(asdict(result))
         # Out to file
         file.write(str(result_json) + os.linesep)
 

--- a/metriq_gym/dispatch_qv.py
+++ b/metriq_gym/dispatch_qv.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import sys
 
 from dataclasses import asdict
 
@@ -20,7 +21,7 @@ def main():
     if args.token:
         QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
 
-    logging.info(f"Dispatching job with n={args.n}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
+    logging.info(f"Dispatching Quantum Volume job with n={args.n}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
 
     result = dispatch_bench_job(args.n, args.backend, args.shots, args.trials)
 
@@ -37,9 +38,7 @@ def main():
     result_json = json.dumps(asdict(result))
 
     with open(args.jobs_file, "a") as file:
-        # Out to file
         file.write(str(result_json) + os.linesep)
-
 
     logging.info(f"Done writing job IDs to file {args.jobs_file}.")
 
@@ -47,4 +46,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/metriq_gym/hardware/clops_benchmark.py
+++ b/metriq_gym/hardware/clops_benchmark.py
@@ -19,6 +19,7 @@ import numpy as np
 from qiskit import transpile
 from qiskit.circuit import Barrier, Delay, ParameterVector, QuantumCircuit, Qubit
 from qiskit.circuit.library import IGate, RZGate, SXGate, UGate
+from qiskit.providers import Job, JobStatus
 from qiskit_ibm_runtime import QiskitRuntimeService, Session
 from qiskit_ibm_runtime import SamplerV2 as Sampler
 from qiskit_ibm_runtime import SamplerOptions
@@ -369,6 +370,7 @@ class clops_benchmark:
         circuit_type: str = "twirled",
         batch_size: int = None,
         pipelines: int = 1,
+        job: Job = None,
     ):
         
         """Run CLOPS benchmark through Sampler primitive
@@ -406,10 +408,10 @@ class clops_benchmark:
                                "batch_size": batch_size, "pipelines": pipelines}
         
         if circuit_type == "twirled":
-            self.job = run_twirled(backend, width, layers, shots, rep_delay, num_circuits)
+            self.job = job if job is not None else run_twirled(backend, width, layers, shots, rep_delay, num_circuits)
             self.clops = self._clops_throughput_sampler
         elif circuit_type == "parameterized":
-            self.job = run_parameterized(backend, width, layers, shots, rep_delay, num_circuits)
+            self.job = job if job is not None else run_parameterized(backend, width, layers, shots, rep_delay, num_circuits)
             self.clops = self._clops_throughput_sampler
         elif circuit_type == "instantiated":
             raise ValueError("'circuit_type' instantiated not yet supported")

--- a/metriq_gym/poll_clops.py
+++ b/metriq_gym/poll_clops.py
@@ -1,9 +1,6 @@
 """Dispatch a CLOPS job with CLI parameters to Qiskit and wait for result."""
-import json
 import logging
-import os
-
-from dataclasses import asdict
+import sys
 
 from qiskit_ibm_runtime import QiskitRuntimeService
 
@@ -49,4 +46,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/metriq_gym/poll_clops.py
+++ b/metriq_gym/poll_clops.py
@@ -1,0 +1,52 @@
+"""Dispatch a CLOPS job with CLI parameters to Qiskit and wait for result."""
+import json
+import logging
+import os
+
+from dataclasses import asdict
+
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+from metriq_gym.parse import parse_arguments
+from metriq_gym.process import poll_job_results
+from metriq_gym.bench import BenchJobResult, BenchJobType, BenchProvider
+from metriq_gym.hardware.clops_benchmark import clops_benchmark
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+def main():
+    args = parse_arguments()
+
+    if not args.token:
+        raise ValueError("CLOPS benchmark requires an IBMQ token!")
+
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
+
+    logging.info("Polling for CLOPS job results.")
+    results = poll_job_results(args.jobs_file, BenchJobType.CLOPS)
+    result_count = len(results)
+    logging.info(f"Found {result_count} completed jobs.")
+    if result_count == 0:
+        logging.info("No new results: done.")
+        return 0
+    
+    for result in results:
+        clops = clops_benchmark(
+            QiskitRuntimeService(),
+            backend = results.backend,
+            width = result.qubits,
+            layers = result.qubits,
+            shots = result.shots,
+            job = result.job
+        )
+
+        result_str = f"Measured clops of {clops.job_attributes['backend_name']} is {clops.clops()}"
+        logging.info(result_str)
+        print(result_str)
+
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/metriq_gym/poll_qv.py
+++ b/metriq_gym/poll_qv.py
@@ -1,5 +1,6 @@
 """Poll IBM-Q cloud services for job results"""
 import logging
+import sys
 
 from qiskit_ibm_runtime import QiskitRuntimeService
 
@@ -34,4 +35,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/metriq_gym/poll_qv.py
+++ b/metriq_gym/poll_qv.py
@@ -5,6 +5,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 
 from metriq_gym.process import poll_job_results, calc_stats
 from metriq_gym.parse import parse_arguments
+from metriq_gym.bench import BenchJobType
 
 
 logging.basicConfig(level=logging.INFO)
@@ -17,7 +18,7 @@ def main():
         QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
 
     logging.info("Polling for job results.")
-    results = poll_job_results(args.jobs_file)
+    results = poll_job_results(args.jobs_file, BenchJobType.QV)
     result_count = len(results)
     logging.info(f"Found {result_count} completed jobs.")
     if result_count == 0:

--- a/metriq_gym/process.py
+++ b/metriq_gym/process.py
@@ -46,15 +46,17 @@ def poll_job_results(jobs_file: str, job_type: BenchJobType) -> list[BenchJobRes
             if (status == JobStatus.RUNNING) or (result.job_type != job_type):
                 # Still running
                 lines_out.append(line)
-            elif status == DONE:
+            elif status == JobStatus.DONE:
                 # Success
                 result.job = job
                 if job_type == BenchJobType.QV:
                     result = get_job_result(job, result)
                 results.append(result)
-            # else: # Failure
+            else:
+                # Failure
+                print(f"Job ID {job.job_id()} failed with status: {status}.")
 
-    with open(jobs_file, 'w') as file:
+    with open(jobs_file, "w") as file:
         file.writelines(lines_out)
 
     return results
@@ -131,7 +133,6 @@ def calc_stats(results: list[BenchJobResult], confidence_level: float) -> dict:
         stats["trials"] = len(result.counts)
 
         if stats["trials"] == 1:
-            logging.info(f"Single trial results: {stats}")
             to_ret.append(stats)
             
             continue

--- a/metriq_gym/process.py
+++ b/metriq_gym/process.py
@@ -8,7 +8,7 @@ from scipy.stats import binom
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit.providers import Job, JobStatus
 
-from metriq_gym.bench import BenchJobResult, BenchProvider
+from metriq_gym.bench import BenchJobResult, BenchJobType, BenchProvider
 
 def get_job(result: BenchJobResult) -> Job:
     if result.provider == BenchProvider.IBMQ:
@@ -25,7 +25,7 @@ def get_job_result(job: Job, partial_result: BenchJobResult):
     return partial_result
 
 
-def poll_job_results(jobs_file: str) -> list[BenchJobResult]:
+def poll_job_results(jobs_file: str, job_type: BenchJobType) -> list[BenchJobResult]:
     """Run quantum volume benchmark using QrackSimulator and return structured results.
 
     Args:
@@ -43,12 +43,15 @@ def poll_job_results(jobs_file: str) -> list[BenchJobResult]:
             result = BenchJobResult(**(json.loads(line)))
             job = get_job(result)
             status = job.status()
-            if status == JobStatus.RUNNING:
+            if (status == JobStatus.RUNNING) or (result.job_type != job_type):
                 # Still running
                 lines_out.append(line)
             elif status == DONE:
                 # Success
-                results.append(get_job_result(job, result))
+                result.job = job
+                if job_type == BenchJobType.QV:
+                    result = get_job_result(job, result)
+                results.append(result)
             # else: # Failure
 
     with open(jobs_file, 'w') as file:


### PR DESCRIPTION
Beware: this code has not been tested with an actual IBMQ account token!

This should split CLOPS benchmarks into separate dispatch and polling steps, without the need to keep a Python shell open. This works by retrieving the CLOPS benchmark job from cloud runtime services and "side-loading" it back into the benchmark-runner class when its status is `DONE`.