### PR TITLE
Adding the ability to specify number of qubits via the command line

### DIFF
--- a/metriq_gym/dispatch_clops.py
+++ b/metriq_gym/dispatch_clops.py
@@ -23,13 +23,13 @@ def main():
 
     QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
 
-    logging.info(f"Dispatching CLOPS job with n={args.n}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
+    logging.info(f"Dispatching CLOPS job with n={args.num_qubits}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
 
     clops = clops_benchmark(
         QiskitRuntimeService(),
         args.backend,
-        width = args.n,
-        layers = args.n,
+        width = args.num_qubits,
+        layers = args.num_qubits,
         shots = args.shots
     )
     

--- a/metriq_gym/dispatch_qv.py
+++ b/metriq_gym/dispatch_qv.py
@@ -19,11 +19,11 @@ def main():
     args = parse_arguments()
 
     if args.token:
-        QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
+        QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True, instance="ibm-q-ornl/ornl/phy147")
 
-    logging.info(f"Dispatching Quantum Volume job with n={args.n}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
+    logging.info(f"Dispatching Quantum Volume job with n={args.num_qubits}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
 
-    result = dispatch_bench_job(args.n, args.backend, args.shots, args.trials)
+    result = dispatch_bench_job(args.num_qubits, args.backend, args.shots, args.trials)
 
     if len(result.counts) > 0:
         stats = calc_stats([result], args.confidence_level)

--- a/metriq_gym/parse.py
+++ b/metriq_gym/parse.py
@@ -9,7 +9,7 @@ def parse_arguments() -> argparse.Namespace:
         Parsed arguments as an argparse.Namespace object.
     """
     parser = argparse.ArgumentParser(description="Quantum volume certification")
-    parser.add_argument("-n", type=int, default=8, help="Number of qubits (default is 8)")
+    parser.add_argument("-n", "--num_qubits", type=int, default=8, help="Number of qubits (default is 8)")
     parser.add_argument("-s", "--shots", type=int, default=8, help="Number of shots per trial (default is 8)")
     parser.add_argument("-t", "--trials", type=int, default=8, help="Number of trials (default is 8)")
     parser.add_argument("-b", "--backend", type=str, default="qasm_simulator", help="Backend to use (default is \"qasm_simulator\")")


### PR DESCRIPTION
Minor tweak to allow the ability to specify the number of qubits for a given dispatch run:

```bash
python metriq_gym/dispatch_qv.py --shots 100 --backend ibm_nazca --trials 10 --n 7 --token  <TOKEN>
```

