### PR TITLE
Fix dispatching CLOPS jobs

### DIFF
--- a/metriq_gym/dispatch_clops.py
+++ b/metriq_gym/dispatch_clops.py
@@ -18,36 +18,35 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 def main():
     args = parse_arguments()
 
-    if not args.token:
-        raise ValueError("CLOPS benchmark requires an IBMQ token!")
-
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
+    if args.token:
+        QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
 
     logging.info(f"Dispatching CLOPS job with n={args.num_qubits}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
 
     clops = clops_benchmark(
-        QiskitRuntimeService(),
-        args.backend,
-        width = args.num_qubits,
-        layers = args.num_qubits,
-        shots = args.shots
+        service=QiskitRuntimeService(),
+        backend_name=args.backend,
+        width=args.num_qubits,
+        layers=args.num_qubits,
+        shots=args.shots
     )
     
-    result = BenchJobResult(
+    partial_result = BenchJobResult(
         id = clops.job.job_id(),
+        backend=args.backend,
         provider = BenchProvider.IBMQ,
         job_type = BenchJobType.CLOPS,
-        qubits = clops.job_attributes.width,
-        shots = clops.job_attributes.shots,
-        depth = clops.job_attributes.layers,
+        qubits = clops.job_attributes["width"],
+        shots = clops.job_attributes["shots"],
+        depth = clops.job_attributes["layers"],
         ideal_probs = [],
         counts = [],
-        interval = result.time_taken,
+        interval = 0,
         sim_interval = 0
     )
 
     # Convert dataclass to string (JSON)
-    result_json = json.dumps(result.to_serializable())
+    result_json = json.dumps(partial_result.to_serializable())
 
     with open(args.jobs_file, "a") as file:
         file.write(str(result_json) + os.linesep)

--- a/metriq_gym/dispatch_qv.py
+++ b/metriq_gym/dispatch_qv.py
@@ -16,9 +16,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 def main():
     args = parse_arguments()
 
-    if args.token:
-        QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
-
     logging.info(f"Dispatching Quantum Volume job with n={args.num_qubits}, shots={args.shots}, trials={args.trials}, backend={args.backend}, confidence_level={args.confidence_level}, jobs_file={args.jobs_file}")
 
     result = dispatch_bench_job(args.num_qubits, args.backend, args.shots, args.trials)

--- a/metriq_gym/poll_clops.py
+++ b/metriq_gym/poll_clops.py
@@ -15,10 +15,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 def main():
     args = parse_arguments()
 
-    if not args.token:
-        raise ValueError("CLOPS benchmark requires an IBMQ token!")
-
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
+    if args.token:
+        QiskitRuntimeService.save_account(channel="ibm_quantum", token=args.token, set_as_default=True, overwrite=True)
 
     logging.info("Polling for CLOPS job results.")
     results = poll_job_results(args.jobs_file, BenchJobType.CLOPS)
@@ -30,7 +28,7 @@ def main():
     
     for result in results:
         clops = clops_benchmark(
-            QiskitRuntimeService(),
+            service=QiskitRuntimeService(),
             backend = results.backend,
             width = result.qubits,
             layers = result.qubits,


### PR DESCRIPTION
Some miscellaneaous fixes to make the dispatch code run for CLOPS-type jobs.

Notes: 
1. Still not working against the Aer simulators (coming in a followup PR)
2. I am looking into fixing the polling part (also coming in a followup PR)

Testing:
```
python metriq_gym/dispatch_clops.py -n 2 --shots 10 --backend ibm_sherbrooke
```