### PR TITLE
refactor: consolidate logger to main program entry point.

### DIFF
--- a/metriq_gym/process.py
+++ b/metriq_gym/process.py
@@ -20,9 +20,6 @@ from metriq_gym.job_manager import JobManager
 from metriq_gym.bench import BenchJobResult, BenchJobType, BenchProvider
 
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-
-
 def get_job(result: BenchJobResult) -> Job:
     if result.provider == BenchProvider.IBMQ:
         return QiskitRuntimeService().job(result.provider_job_id)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -10,11 +10,11 @@ from metriq_gym.cli import parse_arguments
 from metriq_gym.job_type import JobType
 from metriq_gym.schema_validator import load_and_validate
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-
 
 def main() -> int:
     """Main entry point for the CLI."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
     load_dotenv()
     args = parse_arguments()
     job_manager = JobManager()


### PR DESCRIPTION
Closes: #82

- The `run.py` file contains the main entry point for the program execution, so the logging format is instantiated there.
- The other place where `logging.basicConfig` was used is now removed.