### PR TITLE
Remove cli arguments specific to benchmarks

### DIFF
--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -56,15 +56,6 @@ def parse_arguments() -> argparse.Namespace:
         help="Path to the file containing the benchmark parameters",
     )
     dispatch_parser.add_argument(
-        "-n", "--num_qubits", type=int, default=8, help="Number of qubits (default is 8)"
-    )
-    dispatch_parser.add_argument(
-        "-s", "--shots", type=int, default=8, help="Number of shots per trial (default is 8)"
-    )
-    dispatch_parser.add_argument(
-        "-t", "--trials", type=int, default=8, help="Number of trials (default is 8)"
-    )
-    dispatch_parser.add_argument(
         "-p",
         "--provider",
         type=str,


### PR DESCRIPTION
# Description

This is a clean-up PR to remove CLI arguments leftover from old code. Benchmark-specific arguments are now passed via the schema instance file.

# Issue ticket number and link

Fixes # (issue)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

I couldn't find any place where those parameters were documented.

# How Has This Been Tested?

Run unit tests and smoke tested a dispatch/poll run.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
