### PR TITLE
Encapsulate benchmark results in objects

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -3,12 +3,17 @@ import argparse
 from pydantic import BaseModel
 from dataclasses import dataclass
 
-from qbraid import QuantumDevice, ResultData
+from qbraid import GateModelResultData, QuantumDevice
 
 
 @dataclass
 class BenchmarkData:
     provider_job_ids: list[str]
+
+
+@dataclass
+class BenchmarkResult:
+    pass
 
 
 class Benchmark:
@@ -26,6 +31,6 @@ class Benchmark:
     def poll_handler(
         self,
         job_data: BenchmarkData,
-        result_data: list[ResultData],
-    ) -> None:
+        result_data: list[GateModelResultData],
+    ) -> BenchmarkResult:
         raise NotImplementedError

--- a/metriq_gym/benchmarks/quantum_volume.py
+++ b/metriq_gym/benchmarks/quantum_volume.py
@@ -3,14 +3,14 @@ import statistics
 from scipy.stats import binom
 from dataclasses import dataclass
 
-from qbraid import QuantumDevice, QuantumJob, ResultData
+from qbraid import GateModelResultData, QuantumDevice, QuantumJob
 from qbraid.runtime.result_data import MeasCount
 from pyqrack import QrackSimulator
 from qiskit import QuantumCircuit
 
 from metriq_gym.circuits import qiskit_random_circuit_sampling
 
-from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData
+from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
 from metriq_gym.task_helpers import flatten_counts
 
 
@@ -22,6 +22,13 @@ class QuantumVolumeData(BenchmarkData):
     confidence_level: float
     ideal_probs: list[list[float]]
     trials: int
+
+
+@dataclass
+class QuantumVolumeResult(BenchmarkResult):
+    num_qubits: int
+    confidence_pass: bool
+    xeb: float
 
 
 def prepare_qv_circuits(n: int, num_trials: int) -> tuple[list[QuantumCircuit], list[list[float]]]:
@@ -205,10 +212,15 @@ class QuantumVolume(Benchmark):
             trials=trials,
         )
 
-    def poll_handler(self, job_data: BenchmarkData, result_data: list[ResultData]) -> None:
+    def poll_handler(
+        self, job_data: BenchmarkData, result_data: list[GateModelResultData]
+    ) -> BenchmarkResult:
         if not isinstance(job_data, QuantumVolumeData):
             raise TypeError(f"Expected job_data to be of type {type(QuantumVolumeData)}")
 
         stats: AggregateStats = calc_stats(job_data, flatten_counts(result_data))
-        if stats.confidence_pass:
-            print(f"Quantum Volume benchmark for {job_data.num_qubits} qubits passed.")
+        return QuantumVolumeResult(
+            num_qubits=job_data.num_qubits,
+            confidence_pass=stats.confidence_pass,
+            xeb=1,
+        )

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -89,7 +89,7 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     ]
     if all(task.status() == JobStatus.COMPLETED for task in quantum_job):
         result_data: list[ResultData] = [task.result().data for task in quantum_job]
-        handler.poll_handler(job_data, result_data)
+        print(handler.poll_handler(job_data, result_data))
     else:
         logger.info("Job is not yet completed. Please try again later.")
 

--- a/metriq_gym/topology_helpers.py
+++ b/metriq_gym/topology_helpers.py
@@ -52,7 +52,7 @@ def largest_connected_size(good_graph: rx.PyGraph) -> int:
     return len(largest_cc)
 
 
-def _convert_rustworkx_to_networkx(graph: rx.PyGraph) -> nx.Graph:
+def convert_rustworkx_to_networkx(graph: rx.PyGraph) -> nx.Graph:
     """Convert a rustworkx PyGraph or PyDiGraph to a networkx graph.
 
     Adapted from:
@@ -85,7 +85,8 @@ def device_graph_coloring(topology_graph: rx.PyGraph) -> GraphColoring:
     Returns:
         GraphColoring: An object containing the coloring information.
     """
-    num_nodes = _convert_rustworkx_to_networkx(topology_graph).number_of_nodes()
+    num_nodes = convert_rustworkx_to_networkx(topology_graph).number_of_nodes()
+
     # Graphs are bipartite, so use that feature to prevent extra colors from greedy search.
     # This graph is colored using a bipartite edge-coloring algorithm.
     edge_color_map = rx.graph_bipartite_edge_color(topology_graph)
@@ -109,6 +110,6 @@ def device_topology(device: QuantumDevice) -> nx.Graph:
     if isinstance(device, QiskitBackend):
         return device._backend.coupling_map.graph.to_undirected(multigraph=False)
     elif isinstance(device, BraketDevice):
-        return rx.networkx_converter(nx.Graph(device._device.topology_graph.to_undirected()))
+        return rx.networkxconverter(nx.Graph(device._device.topology_graph.to_undirected()))
 
     raise ValueError("Device type not supported.")

--- a/metriq_gym/topology_helpers.py
+++ b/metriq_gym/topology_helpers.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass, field
+from qbraid import QuantumDevice
+from qbraid.runtime import QiskitBackend, BraketDevice
+
+import networkx as nx
+import rustworkx as rx
+import numpy as np
+
+
+@dataclass
+class GraphColoring:
+    """A simple class containing graph coloring data.
+
+    Attributes:
+        num_nodes: Number of qubits (nodes) in the graph.
+        edge_color_map: Maps each edge index to a color (integer).
+        edge_index_map: Maps edge indices to actual qubit pairs.
+        num_colors: Total number of colors assigned in the graph.
+    """
+
+    num_nodes: int
+    edge_color_map: dict
+    edge_index_map: dict
+    num_colors: int = field(init=False)
+
+    def __post_init__(self):
+        self.num_colors = max(self.edge_color_map.values()) + 1
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GraphColoring":
+        """Reconstruct GraphColoring from a dictionary, ensuring integer keys."""
+        return cls(
+            num_nodes=data["num_nodes"],
+            edge_color_map={int(k): v for k, v in data["edge_color_map"].items()},
+            edge_index_map={int(k): v for k, v in data["edge_index_map"].items()},
+        )
+
+
+def largest_connected_size(good_graph: rx.PyGraph) -> int:
+    """Finds the size of the largest connected component in the CHSH subgraph.
+
+    Args:
+        good_graph: The graph of qubit pairs that violated CHSH inequality.
+
+    Returns:
+        The size of the largest connected component.
+    """
+    if good_graph.num_nodes() == 0:
+        return 0
+    cc = rx.connected_components(good_graph)
+    largest_cc = cc[np.argmax([len(g) for g in cc])]
+    return len(largest_cc)
+
+
+def _convert_rustworkx_to_networkx(graph: rx.PyGraph) -> nx.Graph:
+    """Convert a rustworkx PyGraph or PyDiGraph to a networkx graph.
+
+    Adapted from:
+    https://www.rustworkx.org/dev/networkx.html#converting-from-a-networkx-graph
+    """
+    edge_list = [(graph[x[0]], graph[x[1]], {"weight": x[2]}) for x in graph.weighted_edge_list()]
+    graph_type = (
+        nx.MultiGraph
+        if graph.multigraph
+        else nx.Graph
+        if isinstance(graph, rx.PyGraph)
+        else nx.MultiDiGraph
+        if graph.multigraph
+        else nx.DiGraph
+    )
+    return graph_type(edge_list)
+
+
+def device_graph_coloring(topology_graph: rx.PyGraph) -> GraphColoring:
+    """Performs graph coloring for a quantum device's topology.
+
+    The goal is to assign colors to edges such that no two adjacent edges have the same color.
+    This ensures independent BSEQ experiments can be run in parallel. Identifies qubit pairs (edges)
+    that can be executed without interference. These pairs are grouped by "color." The coloring reduces
+    the complexity of the benchmarking process by organizing the graph into independent sets of qubit pairs.
+
+    Args:
+        topology_graph: The topology graph (coupling map) of the quantum device.
+
+    Returns:
+        GraphColoring: An object containing the coloring information.
+    """
+    num_nodes = _convert_rustworkx_to_networkx(topology_graph).number_of_nodes()
+    # Graphs are bipartite, so use that feature to prevent extra colors from greedy search.
+    # This graph is colored using a bipartite edge-coloring algorithm.
+    edge_color_map = rx.graph_bipartite_edge_color(topology_graph)
+
+    # Get the index of the edges.
+    edge_index_map = dict(topology_graph.edge_index_map())
+    return GraphColoring(
+        num_nodes=num_nodes, edge_color_map=edge_color_map, edge_index_map=edge_index_map
+    )
+
+
+def device_topology(device: QuantumDevice) -> nx.Graph:
+    """Extracts the device topology graph from a QuantumDevice object.
+
+    Args:
+        device: The QuantumDevice object.
+
+    Returns:
+        The device topology graph.
+    """
+    if isinstance(device, QiskitBackend):
+        return device._backend.coupling_map.graph.to_undirected(multigraph=False)
+    elif isinstance(device, BraketDevice):
+        return rx.networkx_converter(nx.Graph(device._device.topology_graph.to_undirected()))
+
+    raise ValueError("Device type not supported.")

--- a/metriq_gym/topology_helpers.py
+++ b/metriq_gym/topology_helpers.py
@@ -110,6 +110,6 @@ def device_topology(device: QuantumDevice) -> nx.Graph:
     if isinstance(device, QiskitBackend):
         return device._backend.coupling_map.graph.to_undirected(multigraph=False)
     elif isinstance(device, BraketDevice):
-        return rx.networkxconverter(nx.Graph(device._device.topology_graph.to_undirected()))
+        return rx.networkx_converter(nx.Graph(device._device.topology_graph.to_undirected()))
 
     raise ValueError("Device type not supported.")

--- a/tests/test_topology_helpers.py
+++ b/tests/test_topology_helpers.py
@@ -1,9 +1,23 @@
+import pytest
+from unittest.mock import MagicMock
+import networkx as nx
 import rustworkx as rx
-from metriq_gym.topology_helpers import largest_connected_size
+
+from qbraid import QuantumDevice
+from qbraid.runtime import QiskitBackend
+
+from metriq_gym.topology_helpers import (
+    convert_rustworkx_to_networkx,
+    device_graph_coloring,
+    device_topology,
+    largest_connected_size,
+    GraphColoring,
+)
 
 
+# Tests for largest_connected_size:
 def test_largest_connected_size_single_component():
-    # Create a C5 graph with a single connected component
+    """Test a C5 graph with a single connected component."""
     graph = rx.PyGraph()
     graph.add_nodes_from(range(5))
     graph.add_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1), (3, 4, 1)])
@@ -12,7 +26,7 @@ def test_largest_connected_size_single_component():
 
 
 def test_largest_connected_size_multiple_components():
-    # Create a graph with two connected components
+    """Test a graph with two connected components."""
     graph = rx.PyGraph()
     graph.add_nodes_from(range(7))
     graph.add_edges_from([(0, 1, 1), (1, 2, 1), (3, 4, 1), (4, 5, 1)])
@@ -21,7 +35,7 @@ def test_largest_connected_size_multiple_components():
 
 
 def test_largest_connected_size_disconnected_nodes():
-    # Create a graph with disconnected nodes
+    """Test a graph with disconnected nodes."""
     graph = rx.PyGraph()
     graph.add_nodes_from(range(5))
     graph.add_edges_from([(0, 1, 1), (2, 3, 1)])
@@ -30,7 +44,122 @@ def test_largest_connected_size_disconnected_nodes():
 
 
 def test_largest_connected_size_empty_graph():
-    # Create an empty graph
+    """Test an empty graph."""
     graph = rx.PyGraph()
-
     assert largest_connected_size(graph) == 0
+
+
+# Tests for convert_rustworkx_to_networkx:
+def test_convert_basic_graph():
+    """Test conversion of a simple graph."""
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(3))
+    graph.add_edges_from([(0, 1, 1), (1, 2, 1)])
+
+    nx_graph = convert_rustworkx_to_networkx(graph)
+
+    assert isinstance(nx_graph, nx.Graph)
+    assert set(nx_graph.nodes) == {0, 1, 2}
+    assert set(nx_graph.edges()) == {(0, 1), (1, 2)}
+
+
+def test_convert_multigraph():
+    """Test conversion of a multigraph."""
+    graph = rx.PyGraph(multigraph=True)
+    graph.add_nodes_from(range(3))
+    graph.add_edges_from([(0, 1, 1), (0, 1, 2)])
+
+    nx_graph = convert_rustworkx_to_networkx(graph)
+
+    assert isinstance(nx_graph, nx.MultiGraph)
+    # Two edges between (0,1)
+    assert len(list(nx_graph.edges(0, 1))) == 2
+
+
+def test_convert_empty_graph():
+    """Test conversion of an empty graph."""
+    graph = rx.PyGraph()
+    nx_graph = convert_rustworkx_to_networkx(graph)
+
+    assert isinstance(nx_graph, nx.Graph)
+    assert len(nx_graph.nodes) == 0
+    assert len(nx_graph.edges) == 0
+
+
+# Tests for device_topology:
+def test_device_topology_qiskit():
+    """Test device_topology for a QiskitBackend device."""
+    # Mock the QiskitBackend object
+    mock_backend = MagicMock()
+    mock_backend.coupling_map.graph.to_undirected.return_value = nx.Graph([(0, 1), (1, 2)])
+
+    mock_device = MagicMock(spec=QiskitBackend)
+    mock_device._backend = mock_backend
+
+    topology = device_topology(mock_device)
+
+    assert isinstance(topology, nx.Graph)
+    assert set(topology.nodes) == {0, 1, 2}
+    assert set(topology.edges) == {(0, 1), (1, 2)}
+
+
+def test_device_topology_invalid_device():
+    """Test device_topology with an unsupported device type."""
+    mock_device = MagicMock(spec=QuantumDevice)  # Mock an unknown QuantumDevice
+    with pytest.raises(ValueError, match="Device type not supported."):
+        device_topology(mock_device)
+
+
+# Tests for device_graph_coloring:
+def test_device_graph_coloring_basic():
+    """Test graph coloring for a simple connected graph."""
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(4))
+    graph.add_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1)])
+
+    coloring = device_graph_coloring(graph)
+
+    assert isinstance(coloring, GraphColoring)
+    assert coloring.num_nodes == 4
+    assert set(coloring.edge_index_map.keys()) == set(coloring.edge_color_map.keys())
+    assert max(coloring.edge_color_map.values()) + 1 <= 3  # Should use at most 3 colors
+
+
+def test_device_graph_coloring_disconnected():
+    """Test graph coloring for a graph with two disconnected components."""
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(6))
+    graph.add_edges_from([(0, 1, 1), (2, 3, 1), (4, 5, 1)])
+
+    coloring = device_graph_coloring(graph)
+
+    assert isinstance(coloring, GraphColoring)
+    assert coloring.num_nodes == 6
+    assert max(coloring.edge_color_map.values()) + 1 <= 2  # Should use at most 2 colors
+
+
+def test_device_graph_coloring_bipartite():
+    """Test graph coloring for a bipartite graph."""
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(6))
+    graph.add_edges_from([(0, 3, 1), (0, 4, 1), (1, 4, 1), (1, 5, 1), (2, 5, 1)])
+
+    coloring = device_graph_coloring(graph)
+
+    assert isinstance(coloring, GraphColoring)
+    assert coloring.num_nodes == 6
+    assert max(coloring.edge_color_map.values()) + 1 == 2  # Bipartite graphs need only 2 colors
+
+
+def test_device_graph_coloring_multigraph():
+    """Test graph coloring for a multigraph with parallel edges."""
+    graph = rx.PyGraph(multigraph=True)
+    graph.add_nodes_from(range(3))
+    graph.add_edges_from([(0, 1, 1), (0, 1, 2), (1, 2, 1)])
+
+    coloring = device_graph_coloring(graph)
+
+    assert isinstance(coloring, GraphColoring)
+    assert coloring.num_nodes == 3
+    assert max(coloring.edge_color_map.values()) + 1 <= 3  # Should use at most 3 colors
+    assert len(coloring.edge_index_map) == 3  # Should match the number of edges

--- a/tests/test_topology_helpers.py
+++ b/tests/test_topology_helpers.py
@@ -1,0 +1,36 @@
+import rustworkx as rx
+from metriq_gym.topology_helpers import largest_connected_size
+
+
+def test_largest_connected_size_single_component():
+    # Create a C5 graph with a single connected component
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(5))
+    graph.add_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1), (3, 4, 1)])
+
+    assert largest_connected_size(graph) == 5
+
+
+def test_largest_connected_size_multiple_components():
+    # Create a graph with two connected components
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(7))
+    graph.add_edges_from([(0, 1, 1), (1, 2, 1), (3, 4, 1), (4, 5, 1)])
+    print(graph)
+    assert largest_connected_size(graph) == 3
+
+
+def test_largest_connected_size_disconnected_nodes():
+    # Create a graph with disconnected nodes
+    graph = rx.PyGraph()
+    graph.add_nodes_from(range(5))
+    graph.add_edges_from([(0, 1, 1), (2, 3, 1)])
+
+    assert largest_connected_size(graph) == 2
+
+
+def test_largest_connected_size_empty_graph():
+    # Create an empty graph
+    graph = rx.PyGraph()
+
+    assert largest_connected_size(graph) == 0


### PR DESCRIPTION
# Description

- Extract functions specific to the device topology graph to a helper module
- Encapsulate results of benchmark in objects instead of printing them directly from poll handlers 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested dispatching of new jobs and polling existing jobs.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
