### PR TITLE
Fail gracefully when device is mistyped

### DIFF
--- a/metriq_gym/exceptions.py
+++ b/metriq_gym/exceptions.py
@@ -1,0 +1,2 @@
+class QBraidSetupError(Exception):
+    pass

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -12,6 +12,7 @@ from qbraid.runtime import QuantumDevice, QuantumProvider, load_job, load_provid
 from metriq_gym.benchmarks import BENCHMARK_DATA_CLASSES, BENCHMARK_HANDLERS
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData
 from metriq_gym.cli import list_jobs, parse_arguments
+from metriq_gym.exceptions import QBraidSetupError
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from metriq_gym.schema_validator import load_and_validate
 from metriq_gym.job_type import JobType
@@ -20,17 +21,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class QBraidSetupError(Exception):
-    pass
-
-
 def setup_device(provider_name: str, backend_name: str) -> QuantumDevice:
     """
-    Setup QBraid quantum device for the benchmark.
+    Setup a QBraid device with id backend_name from specified provider.
 
     Args:
-        provider_name (str): Name of the provider.
-        backend_name (str): Name of the device.
+        provider_name: a metriq-gym supported provider name.
+        backend_name: the id of a device supported by the provider.
     Raises:
         QBraidSetupError: If no device matching the name is found in the provider.
     """

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 import pytest
 from datetime import datetime
 from metriq_gym.job_manager import JobManager, MetriqGymJob
-from tests.test_schema_validator import TEST_BENCHMARK_NAME, FakeJobType
+from tests.test_schema_validator import FAKE_BENCHMARK_NAME, FakeJobType
 
 
 @pytest.fixture(autouse=True)
@@ -24,7 +24,7 @@ def sample_job():
         id="test_job_id",
         provider_name="test_provider",
         device_name="test_device",
-        job_type=FakeJobType(TEST_BENCHMARK_NAME),
+        job_type=FakeJobType(FAKE_BENCHMARK_NAME),
         params={},
         data={},
         dispatch_time=datetime.now(),

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -2,12 +2,12 @@ from unittest.mock import patch
 import pytest
 from datetime import datetime
 from metriq_gym.job_manager import JobManager, MetriqGymJob
-from tests.test_schema_validator import TEST_BENCHMARK_NAME, TestJobType
+from tests.test_schema_validator import TEST_BENCHMARK_NAME, FakeJobType
 
 
 @pytest.fixture(autouse=True)
 def patch_job_type_enum():
-    with patch("metriq_gym.job_manager.JobType", TestJobType):
+    with patch("metriq_gym.job_manager.JobType", FakeJobType):
         yield
 
 
@@ -24,7 +24,7 @@ def sample_job():
         id="test_job_id",
         provider_name="test_provider",
         device_name="test_device",
-        job_type=TestJobType(TEST_BENCHMARK_NAME),
+        job_type=FakeJobType(TEST_BENCHMARK_NAME),
         params={},
         data={},
         dispatch_time=datetime.now(),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,48 @@
+import pytest
+from unittest.mock import MagicMock
+from metriq_gym.run import setup_device, QBraidSetupError
+
+
+@pytest.fixture
+def mock_provider():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_device():
+    return MagicMock()
+
+
+@pytest.fixture
+def patch_load_provider(mock_provider, monkeypatch):
+    monkeypatch.setattr("metriq_gym.run.load_provider", lambda _: mock_provider)
+
+
+def test_setup_device_success(mock_provider, mock_device, patch_load_provider):
+    mock_provider.get_device.return_value = mock_device
+
+    provider_name = "test_provider"
+    backend_name = "test_backend"
+
+    device = setup_device(provider_name, backend_name)
+
+    mock_provider.get_device.assert_called_once_with(backend_name)
+    assert device == mock_device
+
+
+def test_setup_device_failure(mock_provider, patch_load_provider, caplog):
+    mock_provider.get_device.side_effect = Exception()
+    mock_provider.get_devices.return_value = [MagicMock(id="device1"), MagicMock(id="device2")]
+
+    provider_name = "test_provider"
+    backend_name = "non_existent_backend"
+
+    with pytest.raises(QBraidSetupError, match="Device not found"):
+        setup_device(provider_name, backend_name)
+
+    # Verify the printed output
+    assert (
+        f"No device matching the name '{backend_name}' found in provider '{provider_name}'."
+        in caplog.text
+    )
+    assert "Devices available: ['device1', 'device2']" in caplog.text

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,6 +1,12 @@
 import pytest
 from unittest.mock import MagicMock
-from metriq_gym.run import setup_device, QBraidSetupError
+from metriq_gym.run import setup_device
+from metriq_gym.exceptions import QBraidSetupError
+
+
+class FakeDevice:
+    def __init__(self, id):
+        self.id = id
 
 
 @pytest.fixture
@@ -10,7 +16,7 @@ def mock_provider():
 
 @pytest.fixture
 def mock_device():
-    return MagicMock()
+    return FakeDevice(id="test_device")
 
 
 @pytest.fixture
@@ -32,7 +38,7 @@ def test_setup_device_success(mock_provider, mock_device, patch_load_provider):
 
 def test_setup_device_failure(mock_provider, patch_load_provider, caplog):
     mock_provider.get_device.side_effect = Exception()
-    mock_provider.get_devices.return_value = [MagicMock(id="device1"), MagicMock(id="device2")]
+    mock_provider.get_devices.return_value = [FakeDevice(id="device1"), FakeDevice(id="device2")]
 
     provider_name = "test_provider"
     backend_name = "non_existent_backend"

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -21,13 +21,13 @@ MOCK_SCHEMA_CONTENT = {
 }
 
 
-class TestJobType(StrEnum):
+class FakeJobType(StrEnum):
     TEST_BENCHMARK = TEST_BENCHMARK_NAME
 
 
 @pytest.fixture(autouse=True)
 def patch_job_type_enum():
-    with patch("metriq_gym.schema_validator.JobType", TestJobType):
+    with patch("metriq_gym.schema_validator.JobType", FakeJobType):
         yield
 
 
@@ -38,7 +38,7 @@ def mock_schema(tmpdir):
         json.dump(MOCK_SCHEMA_CONTENT, schema_file)
 
     SCHEMA_MAPPING = {
-        TestJobType.TEST_BENCHMARK: str(schema_file_path),
+        FakeJobType.TEST_BENCHMARK: str(schema_file_path),
     }
     with patch("metriq_gym.schema_validator.SCHEMA_MAPPING", SCHEMA_MAPPING):
         yield

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -5,14 +5,14 @@ import pytest
 from jsonschema import ValidationError
 from metriq_gym.schema_validator import load_and_validate
 
-TEST_BENCHMARK_NAME = "Test Benchmark"
+FAKE_BENCHMARK_NAME = "Test Benchmark"
 
 MOCK_SCHEMA_CONTENT = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "title": TEST_BENCHMARK_NAME,
+    "title": FAKE_BENCHMARK_NAME,
     "properties": {
-        "benchmark_name": {"type": "string", "const": TEST_BENCHMARK_NAME},
+        "benchmark_name": {"type": "string", "const": FAKE_BENCHMARK_NAME},
         "num_qubits": {"type": "integer", "minimum": 1},
         "shots": {"type": "integer", "minimum": 1},
         "trials": {"type": "integer", "minimum": 1},
@@ -22,7 +22,7 @@ MOCK_SCHEMA_CONTENT = {
 
 
 class FakeJobType(StrEnum):
-    TEST_BENCHMARK = TEST_BENCHMARK_NAME
+    TEST_BENCHMARK = FAKE_BENCHMARK_NAME
 
 
 @pytest.fixture(autouse=True)
@@ -47,7 +47,7 @@ def mock_schema(tmpdir):
 @pytest.fixture
 def valid_params():
     return {
-        "benchmark_name": TEST_BENCHMARK_NAME,
+        "benchmark_name": FAKE_BENCHMARK_NAME,
         "num_qubits": 5,
         "shots": 1024,
         "trials": 10,
@@ -57,7 +57,7 @@ def valid_params():
 @pytest.fixture
 def invalid_params():
     return {
-        "benchmark_name": TEST_BENCHMARK_NAME,
+        "benchmark_name": FAKE_BENCHMARK_NAME,
         "num_qubits": 0,  # Invalid value
         "shots": 1024,
         "trials": 10,


### PR DESCRIPTION
# Description

Whenever the user mistypes the device name, a graceful error is shown, as well as a list of available devices, instead of an ugly stack-trace.

Fixing an issue that occurred during a demo to @rtvuser1

# Issue ticket number and link

Fixes #258

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```sh
metriq-gym-py3.12➜  ✗ python metriq_gym/run.py dispatch metriq_gym/schemas/examples/bseq.example.json --provider ibm --device ibm-nazca
INFO - Starting job dispatch...
ERROR - No device matching the name 'ibm-nazca' found in provider 'ibm'.
INFO - Devices available: ['ibm_brisbane', 'ibm_brussels', 'ibm_fez', 'ibm_kyiv', 'ibm_marrakesh', 'ibm_sherbrooke', 'ibm_strasbourg', 'ibm_torino']
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
