### PR TITLE
Sync dependencies in precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version (keep in sync with the version in pyproject.toml)
-  rev: v0.9.6
+  rev: v0.9.10
   hooks:
     # Run the linter.
     - id: ruff


### PR DESCRIPTION
Unfortunately, there is no automated way to keep the dependencies in sync (see comment in yaml file)