### PR TITLE
Use generics in Benchmark class

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 from dataclasses import dataclass
@@ -20,7 +21,11 @@ class BenchmarkResult:
     pass
 
 
-class Benchmark:
+BD = TypeVar("BD", bound=BenchmarkData)
+BR = TypeVar("BR", bound=BenchmarkResult)
+
+
+class Benchmark(Generic[BD, BR]):
     def __init__(
         self,
         args: argparse.Namespace,
@@ -29,13 +34,13 @@ class Benchmark:
         self.args = args
         self.params: BaseModel = params
 
-    def dispatch_handler(self, device: QuantumDevice) -> BenchmarkData:
+    def dispatch_handler(self, device: QuantumDevice) -> BD:
         raise NotImplementedError
 
     def poll_handler(
         self,
-        job_data: BenchmarkData,
+        job_data: BD,
         result_data: list[GateModelResultData],
         quantum_jobs: list[QuantumJob],
-    ) -> BenchmarkResult:
+    ) -> BR:
         raise NotImplementedError

--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 from dataclasses import dataclass
@@ -21,11 +20,7 @@ class BenchmarkResult:
     pass
 
 
-BD = TypeVar("BD", bound=BenchmarkData)
-BR = TypeVar("BR", bound=BenchmarkResult)
-
-
-class Benchmark(Generic[BD, BR]):
+class Benchmark[BD: BenchmarkData, BR: BenchmarkResult]:
     def __init__(
         self,
         args: argparse.Namespace,

--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -176,14 +176,11 @@ class BSEQ(Benchmark):
 
     def poll_handler(
         self,
-        job_data: BenchmarkData,
+        job_data: BSEQData,
         result_data: list[GateModelResultData],
         quantum_jobs: list[QuantumJob],
     ) -> BSEQResult:
         """Poll and calculate largest connected component."""
-        if not isinstance(job_data, BSEQData):
-            raise TypeError(f"Expected job_data to be of type {type(BSEQData)}")
-
         if not job_data.coloring:
             raise ValueError("Coloring data is required for BSEQ benchmark.")
 

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -151,13 +151,10 @@ class Clops(Benchmark):
 
     def poll_handler(
         self,
-        job_data: BenchmarkData,
+        job_data: ClopsData,
         result_data: list[GateModelResultData],
         quantum_jobs: list[QuantumJob],
     ) -> ClopsResult:
-        if not isinstance(job_data, ClopsData):
-            raise TypeError(f"Expected job_data to be of type {type(ClopsData)}")
-
         clops_score = (self.params.num_circuits * self.params.num_layers * self.params.shots) / sum(
             execution_time(quantum_job) for quantum_job in quantum_jobs
         )

--- a/metriq_gym/benchmarks/qml_kernel.py
+++ b/metriq_gym/benchmarks/qml_kernel.py
@@ -84,13 +84,10 @@ class QMLKernel(Benchmark):
 
     def poll_handler(
         self,
-        job_data: BenchmarkData,
+        job_data: QMLKernelData,
         result_data: list[GateModelResultData],
         quantum_jobs: list[QuantumJob],
     ) -> QMLKernelResult:
-        if not isinstance(job_data, QMLKernelData):
-            raise TypeError(f"Expected job_data to be of type {type(QMLKernelData)}")
-
         return QMLKernelResult(
             accuracy_score=calculate_accuracy_score(
                 self.params.num_qubits, flatten_counts(result_data)[0]

--- a/metriq_gym/benchmarks/quantum_volume.py
+++ b/metriq_gym/benchmarks/quantum_volume.py
@@ -218,13 +218,10 @@ class QuantumVolume(Benchmark):
 
     def poll_handler(
         self,
-        job_data: BenchmarkData,
+        job_data: QuantumVolumeData,
         result_data: list[GateModelResultData],
         quantum_jobs: list[QuantumJob],
-    ) -> BenchmarkResult:
-        if not isinstance(job_data, QuantumVolumeData):
-            raise TypeError(f"Expected job_data to be of type {type(QuantumVolumeData)}")
-
+    ) -> QuantumVolumeResult:
         stats: AggregateStats = calc_stats(job_data, flatten_counts(result_data))
 
         return QuantumVolumeResult(


### PR DESCRIPTION
# Description

It binds intermediate and result data-classes to generics, so we don't need to explicitly check the type of objects that are passed at runtime.

# Issue ticket number and link

Fixes #266 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Running mypy

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
