### PR TITLE
Remove unused pytket dependencies

### DIFF
--- a/metriq_gym/circuits.py
+++ b/metriq_gym/circuits.py
@@ -2,55 +2,7 @@
 
 import math
 import random
-from qiskit import QuantumCircuit, qasm3
-from pytket.circuit import Circuit
-from pytket.extensions.qiskit import qiskit_to_tk as _qiskit_to_tk
-from pyqrack import QrackCircuit
-
-
-def qiskit_to_qasm(circ: QuantumCircuit) -> str:
-    """Convert a Qiskit QuantumCircuit to an OpenQASM 3 string
-
-    Args:
-        circ: QuantumCircuit to translate to OpenQASM 3
-    """
-    return qasm3.dumps(circ)
-
-
-def qasm_to_qiskit(qasm: str) -> QuantumCircuit:
-    """Convert an OpenQASM 3 string to a Qiskit QuantumCircuit
-
-    Args:
-        circ: OpenQASM 3 string to translate to QuantumCircuit
-    """
-    return QuantumCircuit.from_qasm_str(str)
-
-
-def qiskit_to_tk(circ: QuantumCircuit) -> Circuit:
-    """Convert a Qiskit QuantumCircuit to a pytket circuit
-
-    Args:
-        circ: QuantumCircuit to translate to pytket
-    """
-    return _qiskit_to_tk(circ)
-
-
-def qiskit_to_qrack(circ: QuantumCircuit) -> QrackCircuit:
-    """Convert a Qiskit QuantumCircuit to a QrackCircuit
-
-    Args:
-        circ: QuantumCircuit to translate to QrackCircuit
-    """
-    return QrackCircuit.in_from_qiskit_circuit(circ)
-
-
-def qrack_to_qiskit(circ: QrackCircuit) -> QuantumCircuit:
-    """Convert a QrackCircuit to a Qiskit QuantumCircuit
-
-    Args:
-        circ: QrackCircuit to translate to QuantumCircuit
-    """
-    return circ.to_qiskit_circuit()
+from qiskit import QuantumCircuit
 
 
 def rand_u3(circ: QuantumCircuit, q: int) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3373,68 +3373,6 @@ boto3-stubs = "*"
 pytket = ">=1.39.0"
 
 [[package]]
-name = "pytket-qir"
-version = "0.20.0"
-description = "Extension for pytket, providing functions for conversion into to qir"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
-files = [
-    {file = "pytket_qir-0.20.0-py3-none-any.whl", hash = "sha256:429c0339bb8693208f427ada72207db442431302d54bdfd24d577a53e2e120fa"},
-]
-
-[package.dependencies]
-pyqir = "0.10.6"
-pytket = ">=1.40.0,<2"
-
-[[package]]
-name = "pytket-qiskit"
-version = "0.63.0"
-description = "Extension for pytket, providing translation to and from the Qiskit framework"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
-files = [
-    {file = "pytket_qiskit-0.63.0-py3-none-any.whl", hash = "sha256:b2e78fd39035d954b245d97a783db6ce498bc403532288acb686127055bfbce6"},
-]
-
-[package.dependencies]
-numpy = ">=1.26.4"
-pytket = ">=1.39.0"
-qiskit = ">=1.3.1,<1.4.0"
-qiskit-aer = ">=0.15.1"
-qiskit-ibm-runtime = ">=0.30.0"
-
-[[package]]
-name = "pytket-quantinuum"
-version = "0.44.0"
-description = "Extension for pytket, providing access to Quantinuum backends"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
-files = [
-    {file = "pytket_quantinuum-0.44.0-py3-none-any.whl", hash = "sha256:b14b5f0e5801e44c78f826ea0d7a2ffa1553d8abe5016983efab67dec6e83ee5"},
-]
-
-[package.dependencies]
-msal = ">=1.18,<2.0"
-nest_asyncio = ">=1.2"
-numpy = ">=1.26.4"
-pyjwt = ">=2.4,<3.0"
-pytket = ">=1.40.0,<2"
-pytket-qir = ">=0.20,<0.21"
-requests = ">=2.32.2"
-types-requests = "*"
-websockets = ">=13.1"
-
-[package.extras]
-calendar = ["matplotlib (>=3.8.3,<3.11.0)", "pandas (>=2.2.1,<2.3.0)"]
-pecos = ["pytket-pecos (>=0.1.32,<0.2.0)"]
-
-[[package]]
 name = "pytz"
 version = "2025.1"
 description = "World timezone definitions, modern and historical"
@@ -3750,23 +3688,23 @@ test = ["autoqasm (>=0.1.0)", "pytest", "pytest-cov", "qbraid (>=0.8.3,<0.10.0)"
 
 [[package]]
 name = "qiskit"
-version = "1.3.3"
+version = "1.4.2"
 description = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
 files = [
-    {file = "qiskit-1.3.3-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:615e7b86ba9f1f6333321813dc65a46d8feac63ee3c61ee95a7bdb78883e4acf"},
-    {file = "qiskit-1.3.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:eb7a4a79fa2f37171dfa4830b9a620496bfe6177b4581e2c93f502441c06f6af"},
-    {file = "qiskit-1.3.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f94fff07e48e4a1bdbe05adbf70ecf3bb9195b8f6e7a61e3d4c457754c979c3"},
-    {file = "qiskit-1.3.3-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93697239176657742561bb89e0247a4aac0657df7e99f02e3c8f25f8cfc96eb8"},
-    {file = "qiskit-1.3.3-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a8d580a90f29bc63202b552659a0dab0677232fd0c003b669603a872e41ae174"},
-    {file = "qiskit-1.3.3-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fc7165c8773b2f253189e0207cc742ec1b5b6fc8a2acf6975a759504c3b18a17"},
-    {file = "qiskit-1.3.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0910176326b7b394e9891a90c97d2aa00ede842d9b0c538ffa05cf552b8890ef"},
-    {file = "qiskit-1.3.3-cp39-abi3-win32.whl", hash = "sha256:6a926616caf66a41d685c127fe18c1cbea99c0bc4452f0e359ae0d98392abf3d"},
-    {file = "qiskit-1.3.3-cp39-abi3-win_amd64.whl", hash = "sha256:3cd19a734b32585846158d6ba9c950ab7831deb510d2d55688c391ec4ba0aa5c"},
-    {file = "qiskit-1.3.3.tar.gz", hash = "sha256:5a440d82007c32d4d6d3dbe75c279f78ba8f5052369af988f85020820dffa68a"},
+    {file = "qiskit-1.4.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:310d0fa8a3fbb8f6f0e09ba61602e28cf49d084f2b28a20fc965ee966ed79e4e"},
+    {file = "qiskit-1.4.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e079f49557b46e7bef42294477aa16d790d16d4feb6841ed440022e8055ea128"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ba0788b71614a37f8a886563a5122756a50c4bfd40951b54a0083424891d47b"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2ec657c6387e6b32ac950e94ebaed7e897208cd2af42fec00b9c724d997145"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ced4c2229bcf5c47f83f9a5003a97ad5fb69bbb2e7cc9b93ac8b9d2023e79c85"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7b8e6850d806ab56316e64292b099885677ffc0ccdde3c3aafd48096cbb620a"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca3a5b7b7b8079d91daafa60f5f1283cc0dfddc86a78e8fbcd47efbebbfd5ad"},
+    {file = "qiskit-1.4.2-cp39-abi3-win32.whl", hash = "sha256:57c4922863d50109da28ba5de0fc720c16c8b47ed20c69fe51cfa9919d1d22b2"},
+    {file = "qiskit-1.4.2-cp39-abi3-win_amd64.whl", hash = "sha256:4d8043ac40302470fd9c275091a4cd11fd70108f4b70e89fe2764da6281299e1"},
+    {file = "qiskit-1.4.2.tar.gz", hash = "sha256:3cc75cd39d524dfff695d72c7589dfaf945d112ab9e4d4e6a4c06d6ffd439d2f"},
 ]
 
 [package.dependencies]
@@ -3786,63 +3724,6 @@ crosstalk-pass = ["z3-solver (>=4.7)"]
 csp-layout-pass = ["python-constraint (>=1.4)"]
 qasm3-import = ["qiskit-qasm3-import (>=0.1.0)"]
 visualization = ["Pillow (>=4.2.1)", "matplotlib (>=3.3)", "pydot", "pylatexenc (>=1.4)", "seaborn (>=0.9.0)"]
-
-[[package]]
-name = "qiskit-aer"
-version = "0.16.4"
-description = "Aer - High performance simulators for Qiskit"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
-files = [
-    {file = "qiskit_aer-0.16.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:baac0604b5210909176af82c3f9fec54667b23d1f989d2cccc1c26f6d77a4746"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:afaad3357b766720ebc006bdc0e570bffa4cbe0bd46682e9260ae808c9858fde"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1161e025a067f9770e08d5f26e4a17189694e6c5a0a98d5511a0b0d6a101eada"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4eb3e768cb414f235e329598f1e5cd47fe2b72272a81ba8e7864b8be35f5dbcb"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ecca36a70dae5db32362554ff3ed943b545317f5a136e261c1948613188e07c7"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c22d0e3d4bd714d15d0b8a4eeb4d5c6fd7ac391aca753a6f1db3621af4ee300"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-win32.whl", hash = "sha256:98cedb454f16b086b0147fe7d10e7dd3b53d33ba2d990e2f45b444c87ff1ecf1"},
-    {file = "qiskit_aer-0.16.4-cp310-cp310-win_amd64.whl", hash = "sha256:e8061b715e55dcd93ed960256b252e3c75e4065581a0585848ce2482fd2fe9f0"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c098466f0ce2e3f8ede3ba61966970c516f0e5720483a1ba38d2dd3755cc1f4a"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ee9bb703ea62fdfd0534be6814a2f2a6bc330b51fe2d9ad8e7a9d21f53c56627"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbdf8ec7239b8191cbbe8d560ac5e58cb7d532cd288df7ac7a3eb6d2c7bf47d4"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e801d8ec11a4d60961962bde50ad473ab90e868c11919f3c33bf8305509bd757"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c0b95ec32499ef37688554c9b6690daa09e4f211fa6757e76ca2e7142a5766c"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d73b624275b9f5699dd25cc43a8e36e5fd0487eb4848c61b08bc604698e1a42"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-win32.whl", hash = "sha256:fba10ed514fb31a5bd128d3792260f58c79316c821dac4019fbd0ab01aebcf99"},
-    {file = "qiskit_aer-0.16.4-cp311-cp311-win_amd64.whl", hash = "sha256:3d854386536db7f8d33a4c24be4cc1b1322b4dc117a92a119bec93f6a7696c1c"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ea4de52c62ae30591ac5b1d28f780b0a333e778dc858af0e118f842e5cc60700"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:527e95f95e675556a59e057980e5d02e8ba3e44372c0a50622691e025a7ad8e5"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f53bd48b64a91ecf7b067f371bd8f7a1f8f773ffa77df079693c2c31d709b362"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa25632d4ea3bf3e08c0530f99a5f0e69f11f6c098be4341ee77467734a8f6b7"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d4d4cd87ac62a5e4a2eefd71e6aa28d8fcf9573b3273e1c4f9a8798635acb3b"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4991c2226197906c6ea5ff7f1906d9728e250b729f9e80a9429e84c51a04ab12"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-win32.whl", hash = "sha256:6ab8309620af2d415f0ae8abe8a767203067ab6343930eba37ec2eb758862505"},
-    {file = "qiskit_aer-0.16.4-cp312-cp312-win_amd64.whl", hash = "sha256:97ff4270868850b691f9e92ba907b80644bbb34aadbfb2209e29a333d2debf6c"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:32d7332abda22e7be990a4841248fd342ca5825387be5d7346c02335565d371f"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5325f451466d72a11e0a778773694ce30de139e6d2c3f94500e7f095f03ffc7b"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:851fdc6339104ee62c4f740175dda4d16412c623150ad80204d40ea16d302a3c"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:564e9bf849f0636c463ad6b90452deb0ace00e05837026f2bb779d2c0e774561"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dc869151d23183bf4fb293c84e185a6d699c0beddb116136a1456d512991cb1"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-win32.whl", hash = "sha256:9112c06fe96cc31157ad7290446c8597c5c7fa977a6f33f8b0aa9028b24232d8"},
-    {file = "qiskit_aer-0.16.4-cp313-cp313-win_amd64.whl", hash = "sha256:9ca4bc1405c394a91c000b90fed63ed8e02a7d2f4db44684432c3ed313cee507"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9f0752d44a055319f2be54889cd1b28d98bde8a0f77e375a97bb36619e64ff3f"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3bb16dff08097c1dd23e44643b42cc938f55fcdba5a5ed9f04e2a531f5bf73ba"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7847ebc7b28a1e8dc069491cb4168ed7cc52545d1f26a4a2cbbd56120676471a"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58aabdc06d295eeab2d3a773cb9d0448bc5fa4b3dea3508d26d6d002fbe38685"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3161b7eab9f6b00a2be30ee3a7abc15715c27f8874dbc81bb73c39cd88142eb"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d35ff53b2e36a23d7a32465f09d6e034c82ece69b66086cfd05f37ea0535fc37"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-win32.whl", hash = "sha256:c81276ed71207a8961deaaffe00ea2289726d6ff54b96c95f179079a663e6101"},
-    {file = "qiskit_aer-0.16.4-cp39-cp39-win_amd64.whl", hash = "sha256:fa2900ddb81a6144a53af2eb16fc5516e9c4dc4f205e616dadb5f2c6fdc5d07d"},
-    {file = "qiskit_aer-0.16.4.tar.gz", hash = "sha256:5adcdf1b5ee2072215dedec1c6e4381cd35e6dd81123a69abcaa73ae1826446b"},
-]
-
-[package.dependencies]
-numpy = ">=1.16.3"
-psutil = ">=5"
-qiskit = ">=1.1.0"
-scipy = ">=1.0"
 
 [[package]]
 name = "qiskit-device-benchmarking"
@@ -4964,22 +4845,6 @@ files = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.32.0.20250306"
-description = "Typing stubs for requests"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
-files = [
-    {file = "types_requests-2.32.0.20250306-py3-none-any.whl", hash = "sha256:25f2cbb5c8710b2022f8bbee7b2b66f319ef14aeea2f35d80f18c9dbf3b60a0b"},
-    {file = "types_requests-2.32.0.20250306.tar.gz", hash = "sha256:0962352694ec5b2f95fda877ee60a159abdf84a0fc6fdace599f20acb41a03d1"},
-]
-
-[package.dependencies]
-urllib3 = ">=2"
-
-[[package]]
 name = "types-s3transfer"
 version = "0.11.4"
 description = "Type annotations and code completion for s3transfer"
@@ -5139,86 +5004,6 @@ optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
 
 [[package]]
-name = "websockets"
-version = "15.0.1"
-description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or sys_platform != \"darwin\" or platform_machine != \"arm64\" and platform_machine != \"x86_64\""
-files = [
-    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
-    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
-    {file = "websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a"},
-    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e"},
-    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf"},
-    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb"},
-    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d"},
-    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9"},
-    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c"},
-    {file = "websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256"},
-    {file = "websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41"},
-    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431"},
-    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57"},
-    {file = "websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905"},
-    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562"},
-    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792"},
-    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413"},
-    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8"},
-    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3"},
-    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf"},
-    {file = "websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85"},
-    {file = "websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065"},
-    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3"},
-    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665"},
-    {file = "websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2"},
-    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215"},
-    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5"},
-    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65"},
-    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe"},
-    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4"},
-    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597"},
-    {file = "websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9"},
-    {file = "websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7"},
-    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931"},
-    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675"},
-    {file = "websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151"},
-    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22"},
-    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f"},
-    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8"},
-    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375"},
-    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d"},
-    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4"},
-    {file = "websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa"},
-    {file = "websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561"},
-    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5"},
-    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a"},
-    {file = "websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b"},
-    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770"},
-    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb"},
-    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054"},
-    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee"},
-    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed"},
-    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880"},
-    {file = "websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411"},
-    {file = "websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4"},
-    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3"},
-    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1"},
-    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475"},
-    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9"},
-    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04"},
-    {file = "websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122"},
-    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940"},
-    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e"},
-    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9"},
-    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b"},
-    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f"},
-    {file = "websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123"},
-    {file = "websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f"},
-    {file = "websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee"},
-]
-
-[[package]]
 name = "wrapt"
 version = "1.17.2"
 description = "Module for decorators, wrappers and monkey patching."
@@ -5332,4 +5117,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.14,>=3.12"
-content-hash = "5583c52d1d50f72036709782791926dde0f16df8a4b2f9b4ccab246ca6e66c05"
+content-hash = "015cf47349e452d9b736421b113dd003305e45dbf28bc06ce77d87c695b6e92b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,12 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 jsonschema = "^4.23.0"
-matplotlib = "^3.10.0"
 metriq-client = { git = "https://github.com/unitaryfund/metriq-client.git", branch = "master" }
 pyqrack = "^1.36.0"
 python = "<3.14,>=3.12"
 python-dotenv = "^1.0.1"
-pytket = "^1.40.0"
-pytket-qiskit = "^0.63.0"
-pytket-quantinuum = "^0.44.0"
 pydantic = ">=2.5.0,<2.10"
-qiskit = "^1.3.2"
+qiskit = "^1.4.2"
 qiskit-device-benchmarking = { path = "submodules/qiskit-device-benchmarking" }
 qiskit-ibm-runtime = "^0.36.1"
 scipy = "^1.15.2"

--- a/tests/benchmarks/test_quantum_volume.py
+++ b/tests/benchmarks/test_quantum_volume.py
@@ -13,7 +13,7 @@ def test_prepare_qv_circuits(n, trials):
 
 def test_calc_stats_pass():
     job_data = QuantumVolumeData(
-        provider_job_ids="test_job_id",
+        provider_job_ids=["test_job_id"],
         num_qubits=2,
         shots=100,
         depth=2,
@@ -34,7 +34,7 @@ def test_calc_stats_pass():
 
 def test_calc_stats_not_pass():
     job_data = QuantumVolumeData(
-        provider_job_ids="test_job_id",
+        provider_job_ids=["test_job_id"],
         num_qubits=2,
         shots=100,
         depth=2,


### PR DESCRIPTION
# Description

Removes unused circuit conversion functions and consequently pytket dependencies that were preventing a critical security dependency update on Qiskit.

# Issue ticket number and link

Fixes https://github.com/unitaryfund/metriq-gym/security/dependabot/7

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

run pytest

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
