### PR TITLE
Updating QED-C Benchmark Import Paths

### DIFF
--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -22,10 +22,10 @@ from _common import metrics
 
 
 QEDC_BENCHMARK_IMPORTS: dict[JobType, str] = {
-    JobType.BERNSTEIN_VAZIRANI: ".bernstein_vazirani.bv_benchmark",
-    JobType.PHASE_ESTIMATION: ".phase_estimation.pe_benchmark",
-    JobType.HIDDEN_SHIFT: ".hidden_shift.hs_benchmark",
-    JobType.QUANTUM_FOURIER_TRANSFORM: ".quantum_fourier_transform.qft_benchmark",
+    JobType.BERNSTEIN_VAZIRANI: "bernstein_vazirani.bv_benchmark",
+    JobType.PHASE_ESTIMATION: "phase_estimation.pe_benchmark",
+    JobType.HIDDEN_SHIFT: "hidden_shift.hs_benchmark",
+    JobType.QUANTUM_FOURIER_TRANSFORM: "quantum_fourier_transform.qft_benchmark",
 }
 
 """


### PR DESCRIPTION
# Description

The import path for each QED-C benchmark has been updated to remove relative imports. The benchmarks can now be dispatched again. No new dependencies were added. 

# Issue ticket number and link

Fixes #435

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Each QED-C benchmark was dispatched and polled to ensure functionality; they can be dispatched with the same format as the other benchmarks in the repository. No additional test configuration is required. 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
