### PR TITLE
Store results after first poll

### DIFF
--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -226,10 +226,17 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     if not metriq_job:
         return
     print("Polling job...")
-    result = fetch_result(metriq_job, args)
-    if result is None:
-        print(f"Job {metriq_job.id} is not yet completed or has no results.")
-        return
+    result: BenchmarkResult | None = None
+    if metriq_job.result_data is not None:
+        result = BenchmarkResult(**metriq_job.result_data)
+    else:
+        result = fetch_result(metriq_job, args)
+        if result is not None:
+            metriq_job.result_data = result.model_dump()
+            job_manager.update_job(metriq_job)
+        else:
+            print(f"Job {metriq_job.id} is not yet completed or has no results.")
+            return
     export_job_result(args, metriq_job, result)
 
 


### PR DESCRIPTION
# Description

Store results in local db after first poll, so they don't need to be fetched all the time from the remote APIs.
Supersedes #471, which was created before the suite/job refactoring (borrows implementation of JobManager.update_job from there.)

# Issue ticket number and link

Fixes #467 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

e2e smoke test + unit tests

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
