### PR TITLE
No local version segment in wheel filename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ requires-python = ">=3.12"
 mgym = "metriq_gym.run:main"
 
 [tool.poetry]
-version = "0.0.0"  # don't touch; managed by poetry-dynamic-versioning
 packages = [
     { include = "metriq_gym", from = "." },
     { include = "qiskit_device_benchmarking", from = "submodules/qiskit-device-benchmarking" },
@@ -32,6 +31,7 @@ include = [
     { path = "submodules/qiskit-device-benchmarking/LICENSE", format = ["sdist", "wheel"] },
     { path = "submodules/QC-App-Oriented-Benchmarks/LICENSE", format = ["sdist", "wheel"] }
 ]
+version = "0.0.0"  # don't touch; managed by poetry-dynamic-versioning
 
 [tool.poetry.dependencies]
 jsonschema = "^4.23.0"
@@ -98,7 +98,7 @@ enable = true
 vcs = "git"
 style = "pep440"
 # Expect tags like v1.2.3 or 1.2.3; uses latest tag for release builds.
-metadata = true
+metadata = false
 
 [project.entry-points."qbraid.providers"]
 local = "metriq_gym.local.provider:LocalProvider"


### PR DESCRIPTION
Release builds are [failing](https://github.com/unitaryfoundation/metriq-gym/actions/runs/16993803748/job/48179473336) because PyPI/TestPyPI rejects uploads with local version identifiers (+…) even though they're valid per PEP 440, apparently they're not allowed on the public index.

the metadata field controls this, again according to the readme of the plugin: https://github.com/mtkennerly/poetry-dynamic-versioning?tab=readme-ov-file#configuration

Tested with `poetry build` locally

