### PR TITLE
fix: missing version for mgym command

### DIFF
--- a/metriq_gym/__init__.py
+++ b/metriq_gym/__init__.py
@@ -1,3 +1,12 @@
-from ._version import __version__
+from importlib import metadata
+
+try:
+    from ._version import __version__
+except ModuleNotFoundError:
+    # Fallback for editable installs where setuptools_scm has not written _version.py yet.
+    try:
+        __version__ = metadata.version("metriq-gym")
+    except metadata.PackageNotFoundError:
+        __version__ = "0.0.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Closes: #577 

Confirmed the import path succeeds via `python -c "import metriq_gym; print(metriq_gym.__version__)"`

(CC @nonhermitian)