### PR TITLE
Add errorbar for QML Kernel

### DIFF
--- a/metriq_gym/schemas/examples/qml_kernel.example.json
+++ b/metriq_gym/schemas/examples/qml_kernel.example.json
@@ -1,5 +1,5 @@
 {
   "benchmark_name": "QML Kernel",
   "num_qubits": 4,
-  "shots": 1000
+  "shots": 10
 }

--- a/tests/unit/benchmarks/test_benchmark_result.py
+++ b/tests/unit/benchmarks/test_benchmark_result.py
@@ -1,6 +1,11 @@
 import pytest
+from pydantic import Field
 
-from metriq_gym.benchmarks.benchmark import BenchmarkResult, BenchmarkScore
+from metriq_gym.benchmarks.benchmark import (
+    BenchmarkResult,
+    BenchmarkScore,
+    MetricDirection,
+)
 from metriq_gym.exporters.base_exporter import BaseExporter
 
 
@@ -12,7 +17,7 @@ class _DummyExporter(BaseExporter):
 def test_payload_includes_null_uncertainty_for_numeric_and_benchmarkscore(metriq_job):
     # Numeric metric should have uncertainty None (-> null in JSON)
     class _NumResult(BenchmarkResult):
-        numeric_metric: float
+        numeric_metric: float = Field(..., json_schema_extra={"direction": MetricDirection.HIGHER})
 
     num_result = _NumResult(numeric_metric=1.23)
     num_payload = _DummyExporter(metriq_job, num_result).as_dict()
@@ -23,7 +28,9 @@ def test_payload_includes_null_uncertainty_for_numeric_and_benchmarkscore(metriq
 
     # BenchmarkScore without uncertainty should also be None
     class _WitLikeResult(BenchmarkResult):
-        expectation_value: BenchmarkScore
+        expectation_value: BenchmarkScore = Field(
+            ..., json_schema_extra={"direction": MetricDirection.HIGHER}
+        )
 
     bs_result = _WitLikeResult(expectation_value=BenchmarkScore(value=0.7))
     bs_payload = _DummyExporter(metriq_job, bs_result).as_dict()


### PR DESCRIPTION
# Description

Modified `qml_kernel.py` benchmark file to add calculation and output of errorbars.

# Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Checked with simulator and hardware runs.
