### PR TITLE
None uncertainty

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -33,31 +33,35 @@ class BenchmarkData:
 
 class BenchmarkScore(BaseModel):
     value: float
-    uncertainty: float = 0.0
+    # If not specified, treat uncertainty as not available (N/A)
+    uncertainty: float | None = None
 
 
 class BenchmarkResult(BaseModel):
     """Base class for benchmark results.
 
     Subclasses declare metric fields as numbers (float/int) or BenchmarkScore.
-    - Numbers map to results.values[<field>] = number and results.uncertainties[...] = 0.0
-    - BenchmarkScore maps to values[...] = value and uncertainties[...] = uncertainty
+    - Numbers map to results.values[<field>] = number and results.uncertainties[...] = None
+    - BenchmarkScore maps to values[...] = value and uncertainties[...] = uncertainty (or None if unset)
     """
 
     def _iter_metric_items(self):
         for name in self.__class__.model_fields:
             value = getattr(self, name, None)
             if isinstance(value, BenchmarkScore):
-                yield name, float(value.value), float(value.uncertainty)
+                # If uncertainty is not provided, leave as None
+                u = value.uncertainty
+                yield name, float(value.value), (float(u) if u is not None else None)
             elif isinstance(value, (int, float)):
-                yield name, float(value), 0.0
+                # Bare numeric metrics have unspecified uncertainty
+                yield name, float(value), None
 
     @property
     def values(self) -> dict[str, float]:
         return {name: value for name, value, _ in self._iter_metric_items()}
 
     @property
-    def uncertainties(self) -> dict[str, float]:
+    def uncertainties(self) -> dict[str, float | None]:
         return {name: uncertainty for name, _, uncertainty in self._iter_metric_items()}
 
 

--- a/metriq_gym/exporters/cli_exporter.py
+++ b/metriq_gym/exporters/cli_exporter.py
@@ -17,8 +17,9 @@ class CliExporter(BaseExporter):
             print("\nResults:")
             for key in sorted(values):
                 value = values[key]
-                uncertainty = uncertainties.get(key, 0)
-                if not uncertainty:
+                # Preserve explicit 0.0; treat None/empty as missing
+                uncertainty = uncertainties.get(key)
+                if uncertainty is None or uncertainty == "":
                     print(f"  {key}: {value}")
                 else:
                     print(f"  {key}: {value} ± {uncertainty}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+import pytest
+
+from metriq_gym.constants import JobType
+from metriq_gym.job_manager import MetriqGymJob
+
+
+@pytest.fixture
+def metriq_job() -> MetriqGymJob:
+    return MetriqGymJob(
+        id="test-job",
+        job_type=JobType.WIT,
+        params={"benchmark_name": "WIT", "shots": 10},
+        data={"provider_job_ids": ["qid"]},
+        provider_name="provider",
+        device_name="device",
+        dispatch_time=datetime.now(),
+    )

--- a/tests/unit/benchmarks/test_benchmark_result.py
+++ b/tests/unit/benchmarks/test_benchmark_result.py
@@ -1,0 +1,32 @@
+import pytest
+
+from metriq_gym.benchmarks.benchmark import BenchmarkResult, BenchmarkScore
+from metriq_gym.exporters.base_exporter import BaseExporter
+
+
+class _DummyExporter(BaseExporter):
+    def export(self) -> None:  # pragma: no cover - not used in tests
+        raise NotImplementedError
+
+
+def test_payload_includes_null_uncertainty_for_numeric_and_benchmarkscore(metriq_job):
+    # Numeric metric should have uncertainty None (-> null in JSON)
+    class _NumResult(BenchmarkResult):
+        numeric_metric: float
+
+    num_result = _NumResult(numeric_metric=1.23)
+    num_payload = _DummyExporter(metriq_job, num_result).as_dict()
+
+    assert num_payload["results"]["values"]["numeric_metric"] == pytest.approx(1.23)
+    assert "numeric_metric" in num_payload["results"]["uncertainties"]
+    assert num_payload["results"]["uncertainties"]["numeric_metric"] is None
+
+    # BenchmarkScore without uncertainty should also be None
+    class _WitLikeResult(BenchmarkResult):
+        expectation_value: BenchmarkScore
+
+    bs_result = _WitLikeResult(expectation_value=BenchmarkScore(value=0.7))
+    bs_payload = _DummyExporter(metriq_job, bs_result).as_dict()
+
+    assert bs_payload["results"]["values"]["expectation_value"] == pytest.approx(0.7)
+    assert bs_payload["results"]["uncertainties"]["expectation_value"] is None

--- a/tests/unit/benchmarks/test_wit.py
+++ b/tests/unit/benchmarks/test_wit.py
@@ -10,7 +10,6 @@ from metriq_gym.helpers.statistics import (
     binary_expectation_value,
 )
 from metriq_gym.exporters.base_exporter import BaseExporter
-from metriq_gym.exporters.cli_exporter import CliExporter
 from metriq_gym.job_manager import MetriqGymJob
 
 
@@ -71,13 +70,3 @@ def test_wit_result_uncertainty_keys_match_values():
     r = WITResult(expectation_value=BenchmarkScore(value=0.5, uncertainty=0.05))
     assert set(r.values.keys()) == {"expectation_value"}
     assert set(r.uncertainties.keys()) == {"expectation_value"}
-
-
-def test_cli_exporter_displays_value_with_uncertainty(capsys):
-    job = _build_metriq_job()
-    result = WITResult(expectation_value=BenchmarkScore(value=0.5, uncertainty=0.05))
-
-    CliExporter(job, result).export()
-
-    output = capsys.readouterr().out
-    assert "expectation_value: 0.5 ± 0.05" in output

--- a/tests/unit/exporters/test_cli_exporter.py
+++ b/tests/unit/exporters/test_cli_exporter.py
@@ -1,0 +1,23 @@
+from metriq_gym.benchmarks.benchmark import BenchmarkScore
+from metriq_gym.benchmarks.wit import WITResult
+from metriq_gym.exporters.cli_exporter import CliExporter
+
+
+def test_cli_exporter_displays_value_with_uncertainty(metriq_job, capsys):
+    result = WITResult(expectation_value=BenchmarkScore(value=0.5, uncertainty=0.05))
+
+    CliExporter(metriq_job, result).export()
+
+    output = capsys.readouterr().out
+    assert "expectation_value: 0.5 ± 0.05" in output
+
+
+def test_cli_exporter_omits_uncertainty_when_missing(metriq_job, capsys):
+    # When uncertainty is not provided, it should default to None and not be printed
+    result = WITResult(expectation_value=BenchmarkScore(value=0.5))
+
+    CliExporter(metriq_job, result).export()
+
+    output = capsys.readouterr().out
+    assert "expectation_value: 0.5" in output
+    assert "±" not in output

--- a/tests/unit/exporters/test_json_exporter.py
+++ b/tests/unit/exporters/test_json_exporter.py
@@ -1,0 +1,18 @@
+import json
+
+from metriq_gym.benchmarks.benchmark import BenchmarkScore
+from metriq_gym.benchmarks.wit import WITResult
+from metriq_gym.exporters.json_exporter import JsonExporter
+
+
+def test_json_exporter_serializes_none_uncertainty_to_null(metriq_job, tmp_path):
+    result = WITResult(expectation_value=BenchmarkScore(value=0.42))
+    outfile = tmp_path / "result.json"
+
+    JsonExporter(metriq_job, result).export(str(outfile))
+
+    with open(outfile) as f:
+        data = json.load(f)
+
+    assert data["results"]["values"]["expectation_value"] == 0.42
+    assert data["results"]["uncertainties"]["expectation_value"] is None


### PR DESCRIPTION
# Description

When the uncertainty is not calculated, treat it as a special None value, instead of `0.0`, which can be misleadingly interpreted as no errors.

The need of this fix comes from here: https://github.com/unitaryfoundation/metriq-data/pull/12#discussion_r2443503058


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

automated tests

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
