### PR TITLE
Set directions for integers as well

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -76,7 +76,7 @@ class BenchmarkResult(BaseModel):
         for name, field in self.__class__.model_fields.items():
             value = getattr(self, name, None)
             # Only include metrics which are simple numbers or BenchmarkScore
-            if isinstance(value, BenchmarkScore) or (isinstance(value, float)):
+            if isinstance(value, (BenchmarkScore, float)) or type(value) is int:
                 extra = getattr(field, "json_schema_extra", None) or {}
                 direction = extra.get("direction", MetricDirection.HIGHER.value)
                 if isinstance(direction, MetricDirection):

--- a/tests/unit/benchmarks/test_benchmark.py
+++ b/tests/unit/benchmarks/test_benchmark.py
@@ -58,12 +58,11 @@ class TestBenchmarkDirections:
         with pytest.raises(ValueError):
             R(metric=BenchmarkScore(value=0.5, uncertainty=0.1))
 
-    def test_direction_not_required_for_int_or_bool(self):
+    def test_direction_not_required_for_bool(self):
         class R(BenchmarkResult):
-            count: int
             ok: bool
 
-        r = R(count=5, ok=True)
+        r = R(ok=True)
         assert r.directions == {}
 
     def test_directions_from_field_metadata_float(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1378,7 +1378,7 @@ requires-dist = [
     { name = "qbraid", extras = ["azure", "braket", "cirq", "ionq", "qiskit"], specifier = ">=0.10.0,<0.10.1" },
     { name = "qiskit", specifier = ">=1.4.3,<3.0" },
     { name = "qiskit-aer", specifier = ">=0.17.1,<0.18.0" },
-    { name = "qiskit-ibm-runtime", specifier = ">=0.41.1,<0.43.0" },
+    { name = "qiskit-ibm-runtime", specifier = ">=0.41.1,<0.44.0" },
     { name = "qnexus", specifier = ">=0.34.1,<1.0.0" },
     { name = "ruamel-yaml-clib", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = "==0.2.14" },
     { name = "ruamel-yaml-clib", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==0.2.14" },


### PR DESCRIPTION
# Description

Integer metrics were not assigned a direction. This PR fixes that.

Before:
```
    "results": {
      "values": {
        "largest_connected_size": 144.0,
        "fraction_connected": 0.9230769230769231
      },
      "uncertainties": {
        "largest_connected_size": null,
        "fraction_connected": null
      },
      "directions": {
        "fraction_connected": "higher"
      }
```
After:
```
    "results": {
      "values": {
        "largest_connected_size": 144.0,
        "fraction_connected": 0.9230769230769231
      },
      "uncertainties": {
        "largest_connected_size": null,
        "fraction_connected": null
      },
      "directions": {
        "fraction_connected": "higher"
      }
```

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Dry-run of an upload + automated tests

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
