### PR TITLE
Normalize aws device names when exporting

### DIFF
--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -50,7 +50,7 @@ class BaseExporter(ABC):
         device_val = str(platform_info.get("device") or "").strip()
 
         def _is_aws_provider(name: str) -> bool:
-            return name.lower().strip() == "aws"
+            return name.lower() == "aws"
 
         def _simplify_arn_device(device: str) -> str:
             # Split on '/' and take the last two non-empty segments when available.


### PR DESCRIPTION
AWS arns as device name were causing all sort of troubles in the downstream pipeline, so we normalize the way illustrated by this example:

"arn:aws:braket:eu-north-1::device/qpu/iqm/Emerald" --> iqm_emerald 
