### PR TITLE
fix: Batch job result handling for Quantinuum

### DIFF
--- a/metriq_gym/quantinuum/job.py
+++ b/metriq_gym/quantinuum/job.py
@@ -29,14 +29,19 @@ class QuantinuumJob(QuantumJob):
         if not results:
             raise RuntimeError(f"No results available for job {self.id}")
 
-        counts = results[0].download_result().get_counts()
-        norm_counts = {"".join(map(str, k)): v for k, v in counts.items()}
+        all_counts = []
+        for result in results:
+            counts = result.download_result().get_counts()
+            norm_counts = {"".join(map(str, k)): v for k, v in counts.items()}
+            all_counts.append(norm_counts)
+
+        measurement_counts = all_counts[0] if len(all_counts) == 1 else all_counts
 
         return Result(
             device_id=self._device.name if self._device else "unknown",
             job_id=self.id,
             success=True,
-            data=GateModelResultData(measurement_counts=norm_counts),
+            data=GateModelResultData(measurement_counts=measurement_counts),
         )
 
     def status(self) -> JobStatus:


### PR DESCRIPTION
Closes #544

Previously only the first result was processed when handling batch submissions. This fixes the issue by iterating through all results and collecting counts from each one.

For single submissions, returns a dict as before. For batch submissions with multiple circuits, returns a list of dicts.