### PR TITLE
chore: removing root level orphan config

### DIFF
--- a/witconfig.json
+++ b/witconfig.json
@@ -1,5 +1,0 @@
-{
-    "benchmark_name": "WIT", 
-    "num_qubits": 7, 
-    "shots": 8192
-}


### PR DESCRIPTION
Removed file in root directory that likely was added by mistake. 