### PR TITLE
fix: Use `shots` for all QED-C benchmarks (#645)

### DIFF
--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -33,12 +33,12 @@ QEDC_BENCHMARK_IMPORTS: dict[JobType, str] = {
 
 """
 Type: QEDC_Metrics
-Description: 
-    The structure for all returned QED-C circuit metrics. 
+Description:
+    The structure for all returned QED-C circuit metrics.
     The first key represents the number of qubits for the group of circuits.
-    The second key represents the unique identifier for a circuit in the group. 
-        - This may be a secret string for Bernstein-Vazirani, theta value for Phase-Estimation, 
-          and so on. Benchmark specific documentation can be found in QED-C's 
+    The second key represents the unique identifier for a circuit in the group.
+        - This may be a secret string for Bernstein-Vazirani, theta value for Phase-Estimation,
+          and so on. Benchmark specific documentation can be found in QED-C's
           QC-App-Oriented-Benchmarks repository.
     The third key represents the metric being stored.
 Example for Bernstein-Vazirani:
@@ -201,8 +201,12 @@ def get_circuits_and_metrics(
     benchmark = import_benchmark_module(benchmark_name)
 
     # Call the QED-C submodule to get the circuits and creation information.
+    # Conver to QED-C parameter naming conventions.
+    qedc_params = params.copy()
+    if "shots" in qedc_params:
+        qedc_params["num_shots"] = qedc_params.pop("shots")
     circuits, circuit_metrics = benchmark.run(
-        **params,
+        **qedc_params,
         api="qiskit",
         get_circuits=True,
     )

--- a/metriq_gym/schemas/bernstein_vazirani.schema.json
+++ b/metriq_gym/schemas/bernstein_vazirani.schema.json
@@ -1,7 +1,7 @@
 {
   "_comment": "TODO (424)",
   "$id": "metriq-gym/bernstein_vazirani.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",  
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Bernstein-Vazirani",
   "description": "Bernstein-Vazirani benchmark schema definition, describing parameters for the benchmark.",
   "type": "object",
@@ -11,7 +11,7 @@
       "const": "Bernstein-Vazirani",
       "description": "Name of the benchmark. Must be 'Bernstein-Vazirani' for this schema."
     },
-    "num_shots": {
+    "shots": {
       "type": "integer",
       "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
       "default": 1000,

--- a/metriq_gym/schemas/examples/bernstein_vazirani.example.json
+++ b/metriq_gym/schemas/examples/bernstein_vazirani.example.json
@@ -1,6 +1,6 @@
 {
     "benchmark_name": "Bernstein-Vazirani",
-    "num_shots": 1000,
+    "shots": 1000,
     "min_qubits": 2,
     "max_qubits": 6,
     "skip_qubits": 1,

--- a/metriq_gym/schemas/examples/hidden_shift.example.json
+++ b/metriq_gym/schemas/examples/hidden_shift.example.json
@@ -1,6 +1,6 @@
 {
     "benchmark_name": "Hidden Shift",
-    "num_shots": 1000,
+    "shots": 1000,
     "min_qubits": 2,
     "max_qubits": 6,
     "skip_qubits": 1,

--- a/metriq_gym/schemas/examples/phase_estimation.example.json
+++ b/metriq_gym/schemas/examples/phase_estimation.example.json
@@ -1,6 +1,6 @@
 {
     "benchmark_name": "Phase Estimation",
-    "num_shots": 1000,
+    "shots": 1000,
     "min_qubits": 2,
     "max_qubits": 6,
     "skip_qubits": 1,

--- a/metriq_gym/schemas/hidden_shift.schema.json
+++ b/metriq_gym/schemas/hidden_shift.schema.json
@@ -1,7 +1,7 @@
 {
   "_comment": "TODO (424)",
   "$id": "metriq-gym/hidden_shift.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",  
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Hidden Shift",
   "description": "Hidden Shift benchmark schema definition, describing parameters for the benchmark.",
   "type": "object",
@@ -11,7 +11,7 @@
       "const": "Hidden Shift",
       "description": "Name of the benchmark. Must be 'Hidden Shift' for this schema."
     },
-    "num_shots": {
+    "shots": {
       "type": "integer",
       "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
       "default": 1000,

--- a/metriq_gym/schemas/phase_estimation.schema.json
+++ b/metriq_gym/schemas/phase_estimation.schema.json
@@ -1,7 +1,7 @@
 {
   "_comment": "TODO (424)",
   "$id": "metriq-gym/phase_estimation.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",  
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Phase Estimation",
   "description": "Phase Estimation benchmark schema definition, describing parameters for the benchmark.",
   "type": "object",
@@ -11,7 +11,7 @@
       "const": "Phase Estimation",
       "description": "Name of the benchmark. Must be 'Phase Estimation' for this schema."
     },
-    "num_shots": {
+    "shots": {
       "type": "integer",
       "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
       "default": 1000,

--- a/metriq_gym/schemas/quantum_fourier_transform.schema.json
+++ b/metriq_gym/schemas/quantum_fourier_transform.schema.json
@@ -1,7 +1,7 @@
 {
   "_comment": "TODO (424)",
   "$id": "metriq-gym/quantum_fourier_transform.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",  
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Quantum Fourier Transform",
   "description": "Quantum Fourier Transform benchmark schema definition, describing parameters for the benchmark.",
   "type": "object",
@@ -11,7 +11,7 @@
       "const": "Quantum Fourier Transform",
       "description": "Name of the benchmark. Must be 'Quantum Fourier Transform' for this schema."
     },
-    "num_shots": {
+    "shots": {
       "type": "integer",
       "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
       "default": 1000,


### PR DESCRIPTION
# Description

Ensures `shots` is used instead of `num_shots` for all QED-C benchmark schemas and examples. Internally translates back to `num_shots` when calling QED-C functions.

# Issue ticket number and link

Fixes #645 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

For now, this has been tested manually by running say the QFT job against a local simulator. Additionally, as prototyped in #647 (and now in https://github.com/unitaryfoundation/metriq-gym/tree/bc-e2e-test), I was adding an end-to-end test that attempts to run all example configs. There's some loose ends before that is ready, so I wanted to merge this for now to enable users that want to run QED-C benchmarks.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
