### PR TITLE
fix: Use descending lexicographic order for Quantinuum result bitstrings

### DIFF
--- a/metriq_gym/quantinuum/job.py
+++ b/metriq_gym/quantinuum/job.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import qnexus as qnx
+from pytket.circuit import BasisOrder
 from qbraid.runtime import GateModelResultData, JobStatus, QuantumJob, Result
 
 
@@ -31,7 +32,11 @@ class QuantinuumJob(QuantumJob):
 
         all_counts = []
         for result in results:
-            counts = result.download_result().get_counts()
+            # Quantinuum (as documented in pytket) by default uses bitstrings
+            # with the least significant bit first. We convert to
+            # most significant bit first (dlo = descending lexographic order)
+            # for consistency with other backends.
+            counts = result.download_result().get_counts(basis=BasisOrder.dlo)
             norm_counts = {"".join(map(str, k)): v for k, v in counts.items()}
             all_counts.append(norm_counts)
 

--- a/tests/unit/quantinuum/test_counts_normalization.py
+++ b/tests/unit/quantinuum/test_counts_normalization.py
@@ -3,10 +3,12 @@ import types
 
 import metriq_gym.quantinuum.job as qjob
 from qbraid.runtime import GateModelResultData
+from pytket.circuit import BasisOrder
 
 
 class FakeItem:
     def __init__(self, counts):
+        # Assumes count keys are least signficant bit first
         self._counts = counts
 
     def download_result(self):
@@ -14,7 +16,11 @@ class FakeItem:
             def __init__(self, c):
                 self._c = c
 
-            def get_counts(self):
+            def get_counts(self, basis: BasisOrder = BasisOrder.ilo):
+                # Mock the behavior of the BasisOrder argument in pytket
+                if basis == BasisOrder.dlo:
+                    # Convert keys to most significant bit first
+                    return {tuple(reversed(k)): v for k, v in self._c.items()}
                 return self._c
 
         return R(self._counts)
@@ -46,11 +52,13 @@ def test_quantinuum_job_result_normalizes_to_single_bit(monkeypatch):
 
 def test_quantinuum_job_result_handles_batch_submissions(monkeypatch):
     fake_qnx = types.SimpleNamespace()
-    fake_qnx.jobs = FakeJobs([
-        FakeItem({(0, 0): 5, (1, 1): 3}),
-        FakeItem({(0, 1): 7, (1, 0): 2}),
-        FakeItem({(1, 1): 4, (0, 0): 6}),
-    ])
+    fake_qnx.jobs = FakeJobs(
+        [
+            FakeItem({(0, 0): 5, (1, 1): 3}),
+            FakeItem({(0, 1): 7, (1, 0): 2}),
+            FakeItem({(1, 1): 4, (0, 0): 6}),
+        ]
+    )
     monkeypatch.setattr(qjob, "qnx", fake_qnx, raising=True)
 
     job = qjob.QuantinuumJob("batch-job-uuid")
@@ -61,5 +69,5 @@ def test_quantinuum_job_result_handles_batch_submissions(monkeypatch):
     assert isinstance(counts, list)
     assert len(counts) == 3
     assert counts[0] == {"00": 5, "11": 3}
-    assert counts[1] == {"01": 7, "10": 2}
+    assert counts[1] == {"10": 7, "01": 2}
     assert counts[2] == {"11": 4, "00": 6}


### PR DESCRIPTION
# Description

As part of reviewing QFT benchmark results on Quantinuum devices, we [discovered](https://github.com/unitaryfoundation/metriq-gym/pull/633#issuecomment-3634608383) that bitstrings were reversed from the expected order.  It took a little digging, but the nexus API leads to [these](https://docs.quantinuum.com/tket/api-docs/backends.html#pytket.backends.backendresult.BackendResult.get_counts) pytket docs for `get_counts` which has signature:

`get_counts(cbits=None, basis=BasisOrder.ilo, ppcirc=None)`

where [`BasisOrder`](https://docs.quantinuum.com/tket/api-docs/circuit.html#pytket.circuit.BasisOrder) is a enum to define (surprise!) how to order the basis. The default is `ilo` for increasing lexicographic order. For bitstrings in the shot counts, this means the first entry in the string is for the *lowest* lexicographic qubit name (e.g. qubit A or qubit 0). 

Since the existing benchmarks are written in Qiskit, this needs to be switched to `dlo` for descending order, to match the [most-significant bit first ordering in Qiskit](https://docs.quantinuum.com/tket/api-docs/circuit.html#pytket.circuit.BasisOrder), e.g. Qubit 0 is the least significant bit, so it's measurement result goes as the last character in the string.

Separately, this raises a broader question of how to understand and enforce bitstring ordering across devices+platforms and benchmarks. I'll open a discussion issue on that topic.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've updated the unit tests for the Quantinuum job result code to take in this new `basis` argument and act accordingly. That doesn't really test this externally though, so I did that by running a job against the H1-LE emulator on nexus for the circuit below, and manually verifying that the basis order change gives the results expected (which would be the string `10`).

```python
from pytket.circuit import Circuit
from pytket.circuit import BasisOrder

circuit = Circuit(2)
circuit.X(1)
circuit.measure_all()
```
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
