### PR TITLE
mirror_circuits: remove unnecessary barriers

### DIFF
--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -582,8 +582,6 @@ class MirrorCircuits(Benchmark):
             shots = sum(counts.values())
             shots_total += shots
             successes_total += counts.get(expected_bitstring, 0)
-            # print('Expected bitstring:', expected_bitstring)
-            # print(counts)
         if shots_total == 0:
             final_success_probability = 0.0
             final_success_prob_err = 0.0


### PR DESCRIPTION
# Description

Remove unnecessary barriers in the mirror circuit benchmark implementation.

Results tested on IBM devices.

# Issue ticket number and link

Fixes # ([634](https://github.com/unitaryfoundation/metriq-gym/issues/634))

# Type of change

- Bug fix (non-breaking change which fixes an issue)

