### PR TITLE
Treat graph edges symmetrically in mirror circuit benchmark

### DIFF
--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -318,7 +318,7 @@ def random_cliffords(
     two_qubit_gate = CXGate() if gate_type == TwoQubitGateType.CNOT else CZGate()
 
     for u, v in connectivity_graph.edge_list():
-        if random_state.randint(2) == 0:
+        if random_state.choice([True, False]):
             control, target = u, v
         else:
             control, target = v, u


### PR DESCRIPTION
# Description

The direction (control/target) of gates in the 2q layer is now randomized for each edge in the truncated working graph, to match the fact that the original connectivity graph is symmetric.

# Issue ticket number and link

Fixes #635

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit test + e2e workflow on a mirror circuit instance against local simulator

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
