### PR TITLE
Remove EPLG score and just store specific length results

### DIFF
--- a/tests/unit/benchmarks/test_eplg.py
+++ b/tests/unit/benchmarks/test_eplg.py
@@ -1,37 +1,10 @@
 """Unit tests for EPLG benchmark."""
 
-import pytest
 import rustworkx as rx
 
 from metriq_gym.benchmarks.eplg import (
-    eplg_score_at_lengths,
     random_chain_from_graph,
-    EPLGResult,
 )
-
-
-def test_eplg_score_at_lengths_exact_match():
-    """Test EPLG score when targets match chain lengths exactly."""
-    chain_lens = [10, 20, 50, 100]
-    chain_eplgs = [0.01, 0.02, 0.03, 0.04]
-
-    score, picked_vals, picks = eplg_score_at_lengths(chain_lens, chain_eplgs)
-
-    assert score == pytest.approx(0.025)  # average of 0.01, 0.02, 0.03, 0.04
-    assert picked_vals == [0.01, 0.02, 0.03, 0.04]
-    assert picks == [(10, 10), (20, 20), (50, 50), (100, 100)]
-
-
-def test_eplg_score_at_lengths_nearest_neighbor():
-    """Test EPLG score with fallback to nearest chain length."""
-    chain_lens = [4, 6, 8]
-    chain_eplgs = [0.01, 0.02, 0.03]
-
-    score, picked_vals, picks = eplg_score_at_lengths(chain_lens, chain_eplgs)
-
-    # All targets (10, 20, 50, 100) fall back to nearest (8)
-    assert picked_vals == [0.03, 0.03, 0.03, 0.03]
-    assert picks == [(10, 8), (20, 8), (50, 8), (100, 8)]
 
 
 def test_random_chain_from_graph_path():
@@ -53,33 +26,3 @@ def test_random_chain_from_graph_complete():
 
     assert len(chain) == 5
     assert len(set(chain)) == 5
-
-
-def test_eplg_result_compute_score():
-    """Test EPLGResult score computation."""
-    result = EPLGResult(
-        chain_lengths=[4, 6, 8],
-        chain_eplgs=[0.01, 0.02, 0.03],
-        eplg_10=0.03,
-        eplg_20=0.03,
-        eplg_50=0.03,
-        eplg_100=0.03,
-    )
-
-    score = result.compute_score()
-    assert score.value == pytest.approx(0.03)
-
-
-def test_eplg_result_compute_score_partial():
-    """Test EPLGResult score with some None values."""
-    result = EPLGResult(
-        chain_lengths=[4],
-        chain_eplgs=[0.01],
-        eplg_10=0.01,
-        eplg_20=None,
-        eplg_50=None,
-        eplg_100=None,
-    )
-
-    score = result.compute_score()
-    assert score.value == pytest.approx(0.01)


### PR DESCRIPTION
# Description

This change eliminates the EPLG score calculation internal to the benchmark, and just stores the raw scores at chain lengths alongside the specific score for 10,20,50 and 100 qubit chain lengths. This was done because appropriate averaging of the score requires normalization to the baseline device, which has to happen in metriq-data. 

For a chain length that wasn't in the benchmark dataset, the result will be `None`.

This is different than how other benchmarks work, but it is intentional based on the EPLG specific structure. E.g. for QML kernel, the user runs multiple configurations with different number of qubits, each generating a result/score. Those separate results are then combined to determine the metriq-score contribution. However, for EPLG, you get the shorter chain length results for free for a given maximum chain length, so it more efficient to calculate that within the same benchmark set.

# Issue ticket number and link

Fixes #702 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
