### PR TITLE
Add Q-Grade benchmark (Teng et al., arXiv:2503.12573)

### DIFF
--- a/metriq_gym/benchmarks/q_grade.py
+++ b/metriq_gym/benchmarks/q_grade.py
@@ -1,0 +1,286 @@
+"""Q-Grade benchmark implementation.
+
+Summary:
+    Implements the many-body quantum coherence test from Teng et al.
+    (arXiv:2503.12573). For each ring size in ``ring_sizes`` the benchmark
+    submits two Trotterised circuits that encode a tight-binding "particle on
+    a ring" in an Ising-chain with twisted boundary conditions: one with a
+    vison (magnetic pi flux) through the ring and one without. Anyonic
+    statistics cause the vison case to destructively interfere the particle's
+    arrival at the diametrically opposite site; decoherence gradually lifts
+    that blockade. The contrast
+
+        R_gamma(L) = (<n_{L/2}>^{nov}_shots - <n_{L/2}>^{v}_shots)
+                     / (<n_{L/2}>^{nov}_trot  - <n_{L/2}>^{v}_trot)
+
+    is normalised by the noiseless-Trotter values of the *same* circuit so
+    that Trotter error cancels and R_gamma = 1 on a perfect device.
+
+Result interpretation:
+    Polling returns ``QGradeResult`` with:
+        - ``q_grade``: largest ring size in ``ring_sizes`` for which R_gamma
+          meets the configured threshold (default 0.2). Zero if none qualify.
+        - ``r_gamma``: BenchmarkScore at the reported ring size, with binomial
+          uncertainty (SM Note F, Eq. F3).
+    The headline ``score`` exposed via ``compute_score`` is the Q-grade.
+
+References:
+    - [Teng, Scarlatella, Zhou, Rahmani, Chamon, Castelnovo,
+      "Standardized test of many-body coherence in gate-based quantum
+      platforms", arXiv:2503.12573 (2025)](https://arxiv.org/abs/2503.12573).
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+
+from metriq_gym.benchmarks.benchmark import (
+    Benchmark,
+    BenchmarkData,
+    BenchmarkResult,
+    BenchmarkScore,
+)
+from metriq_gym.helpers.task_helpers import flatten_counts
+from metriq_gym.resource_estimation import CircuitBatch
+
+if TYPE_CHECKING:
+    from qbraid import GateModelResultData, QuantumDevice, QuantumJob
+
+
+# -------- Paper parameters (SM Note D) --------
+# Closed-form extrapolations, valid for even L >= 4:
+#   t_max(L) = 5 + 2.75 L   (linear fit to the paper's tabulated first-peak
+#                            times; agrees to within rounding for L = 4..22)
+#   N_opt(L) = L + 2        (empirical minimum for avg Trotter err <= 0.15)
+
+def _validate_L(L: int) -> None:
+    if not isinstance(L, int):
+        raise TypeError(f"L must be an int, got {type(L).__name__}")
+    if L < 4 or L % 2 != 0:
+        raise ValueError(f"L must be an even integer >= 4, got L={L}")
+
+
+def t_max(L: int) -> float:
+    _validate_L(L)
+    return 5.0 + 2.75 * L
+
+
+def n_opt(L: int) -> int:
+    _validate_L(L)
+    return L + 2
+
+
+# -------- Circuit construction --------
+
+def _init_state_prep(qc: QuantumCircuit, n: int, vison: bool) -> None:
+    """GHZ-style preparation of the single-spinon initial state.
+    If ``vison`` is True, precede the Hadamard with an X to introduce a pi
+    flux (vison) through the ring."""
+    if vison:
+        qc.x(0)
+    qc.h(0)
+    for i in range(n - 1):
+        qc.cx(i, i + 1)
+
+
+def _rzz(qc: QuantumCircuit, angle: float, i: int, j: int) -> None:
+    """exp(-i * angle/2 * Z_i Z_j) compiled as CNOT - Rz - CNOT."""
+    qc.cx(i, j)
+    qc.rz(angle, j)
+    qc.cx(i, j)
+
+
+def _interaction_layer(qc: QuantumCircuit, n: int, angle: float) -> None:
+    """One full ZZ layer on the ring: even bonds, then odd bonds, then the
+    twisted bond (n-1, 0) with a MINUS sign (this implements J_0 = -1)."""
+    for i in range(n // 2):
+        _rzz(qc, angle, 2 * i, 2 * i + 1)
+    for i in range(n // 2 - 1):
+        _rzz(qc, angle, 2 * i + 1, 2 * i + 2)
+    _rzz(qc, -angle, n - 1, 0)  # twisted bond
+
+
+def _hopping_layer(qc: QuantumCircuit, n: int, angle: float) -> None:
+    for i in range(n):
+        qc.rx(angle, i)
+
+
+def build_q_grade_circuit(
+    L: int,
+    vison: bool,
+    J: float = 1.0,
+    Gamma: float = 0.1,
+    measure: bool = True,
+) -> QuantumCircuit:
+    """Build the L-site Trotterised circuit for the Q-grade benchmark."""
+    _validate_L(L)
+    t = t_max(L)
+    n_steps = n_opt(L)
+    dt = t / n_steps
+
+    qc = QuantumCircuit(L, L) if measure else QuantumCircuit(L)
+    _init_state_prep(qc, L, vison)
+    for _ in range(n_steps):
+        _interaction_layer(qc, L, 2 * J * dt)
+        _hopping_layer(qc, L, 2 * Gamma * dt)
+    if measure:
+        qc.measure(range(L), range(L))
+    return qc
+
+
+# -------- Readout helpers --------
+
+def _midpoint_from_indexed_probs(probs_by_idx, L: int) -> float:
+    """<n_{L/2}> = Prob(domain wall across qubits L/2 - 1 and L/2).
+
+    Qiskit convention: bits[q] = (idx >> q) & 1, qubit 0 is the least
+    significant bit.
+    """
+    site = L // 2
+    a, b = site - 1, site
+    p = 0.0
+    for idx, pr in probs_by_idx:
+        if ((idx >> a) & 1) != ((idx >> b) & 1):
+            p += pr
+    return float(p)
+
+
+def _midpoint_from_counts(counts: dict, L: int) -> float:
+    shots = sum(counts.values())
+    if shots == 0:
+        return 0.0
+    pairs = ((int(bs.replace(" ", ""), 2), c / shots) for bs, c in counts.items())
+    return _midpoint_from_indexed_probs(pairs, L)
+
+
+def _midpoint_noiseless_trotter(L: int, vison: bool, J: float, Gamma: float) -> float:
+    """Expectation from the same Trotter circuit run as a pure statevector.
+    Used as the R_gamma denominator so Trotter error cancels out."""
+    qc = build_q_grade_circuit(L, vison, J, Gamma, measure=False)
+    psi = Statevector(qc).data
+    probs = ((idx, abs(psi[idx]) ** 2) for idx in range(2 ** L))
+    return _midpoint_from_indexed_probs(probs, L)
+
+
+# -------- Benchmark plumbing --------
+
+class QGradeResult(BenchmarkResult):
+    q_grade: int
+    r_gamma: BenchmarkScore
+
+    def compute_score(self) -> BenchmarkScore:
+        # Expose Q-grade as headline. uncertainty=None (it is a thresholded
+        # integer, not a statistical mean).
+        return BenchmarkScore(value=float(self.q_grade), uncertainty=None)
+
+
+@dataclass
+class QGradeData(BenchmarkData):
+    ring_sizes: list[int] = field(default_factory=list)
+    shots: int = 1000
+    threshold: float = 0.2
+    # Noiseless-Trotter reference values, one entry per ring size (submission order).
+    ref_vison: list[float] = field(default_factory=list)
+    ref_novison: list[float] = field(default_factory=list)
+
+
+class QGrade(Benchmark[QGradeData, QGradeResult]):
+    def _build_circuits(self, device: "QuantumDevice") -> tuple[
+        list[QuantumCircuit], list[float], list[float]
+    ]:
+        """Shared circuit construction: two circuits (vison, no-vison) per
+        ring size, plus the matching noiseless-Trotter reference values."""
+        ring_sizes: list[int] = list(self.params.ring_sizes)
+        j_coupling: float = float(getattr(self.params, "j_coupling", 1.0))
+        gamma_hopping: float = float(getattr(self.params, "gamma_hopping", 0.1))
+
+        circuits: list[QuantumCircuit] = []
+        ref_v: list[float] = []
+        ref_nv: list[float] = []
+        for L in ring_sizes:
+            _validate_L(L)
+            circuits.append(
+                build_q_grade_circuit(L, vison=True,  J=j_coupling, Gamma=gamma_hopping)
+            )
+            circuits.append(
+                build_q_grade_circuit(L, vison=False, J=j_coupling, Gamma=gamma_hopping)
+            )
+            ref_v.append(_midpoint_noiseless_trotter(L, True,  j_coupling, gamma_hopping))
+            ref_nv.append(_midpoint_noiseless_trotter(L, False, j_coupling, gamma_hopping))
+
+        return circuits, ref_v, ref_nv
+
+    def dispatch_handler(self, device: "QuantumDevice") -> QGradeData:
+        circuits, ref_v, ref_nv = self._build_circuits(device)
+        return QGradeData.from_quantum_job(
+            quantum_job=device.run(circuits, shots=self.params.shots),
+            ring_sizes=list(self.params.ring_sizes),
+            shots=self.params.shots,
+            threshold=float(getattr(self.params, "threshold", 0.2)),
+            ref_vison=ref_v,
+            ref_novison=ref_nv,
+        )
+
+    def poll_handler(
+        self,
+        job_data: QGradeData,
+        result_data: list["GateModelResultData"],
+        quantum_jobs: list["QuantumJob"],
+    ) -> QGradeResult:
+        counts_list = flatten_counts(result_data)
+        expected = 2 * len(job_data.ring_sizes)
+        if len(counts_list) != expected:
+            raise RuntimeError(
+                f"Q-Grade: expected {expected} result batches (2 per ring size), "
+                f"got {len(counts_list)}."
+            )
+
+        # R_gamma(L) for every ring size, plus bookkeeping for the headline score.
+        r_by_L: dict[int, float] = {}
+        n_v_by_L: dict[int, float] = {}
+        n_nv_by_L: dict[int, float] = {}
+        for k, L in enumerate(job_data.ring_sizes):
+            n_v = _midpoint_from_counts(counts_list[2 * k], L)
+            n_nv = _midpoint_from_counts(counts_list[2 * k + 1], L)
+            denom = job_data.ref_novison[k] - job_data.ref_vison[k]
+            r_by_L[L] = (n_nv - n_v) / denom if denom != 0 else 0.0
+            n_v_by_L[L] = n_v
+            n_nv_by_L[L] = n_nv
+
+        # Q-grade: largest ring size clearing threshold. If nothing qualifies,
+        # the headline is 0 but we still report R_gamma at the smallest ring
+        # size tested so the user sees a non-trivial number.
+        qualifying = [L for L, r in r_by_L.items() if r >= job_data.threshold]
+        if qualifying:
+            reported_L = max(qualifying)
+            q_grade_value = reported_L
+        else:
+            reported_L = min(job_data.ring_sizes)
+            q_grade_value = 0
+
+        k_rep = job_data.ring_sizes.index(reported_L)
+        denom = job_data.ref_novison[k_rep] - job_data.ref_vison[k_rep]
+        shots = job_data.shots
+        n_v = n_v_by_L[reported_L]
+        n_nv = n_nv_by_L[reported_L]
+        if shots > 0 and denom != 0:
+            var = (
+                (1 - n_v) * n_v + (1 - n_nv) * n_nv
+            ) / (shots * denom ** 2)
+            unc = float(np.sqrt(max(var, 0.0)))
+        else:
+            unc = None
+
+        return QGradeResult(
+            q_grade=q_grade_value,
+            r_gamma=BenchmarkScore(value=float(r_by_L[reported_L]), uncertainty=unc),
+        )
+
+    def estimate_resources_handler(
+        self, device: "QuantumDevice"
+    ) -> list[CircuitBatch]:
+        circuits, _, _ = self._build_circuits(device)
+        return [CircuitBatch(circuits=circuits, shots=self.params.shots)]

--- a/metriq_gym/constants.py
+++ b/metriq_gym/constants.py
@@ -13,6 +13,7 @@ class JobType(StrEnum):
     HIDDEN_SHIFT = "Hidden Shift"
     QUANTUM_FOURIER_TRANSFORM = "Quantum Fourier Transform"
     LR_QAOA = "Linear Ramp QAOA"
+    Q_GRADE = "Q-Grade"
 
 
 SCHEMA_MAPPING = {
@@ -27,4 +28,5 @@ SCHEMA_MAPPING = {
     JobType.HIDDEN_SHIFT: "hidden_shift.schema.json",
     JobType.QUANTUM_FOURIER_TRANSFORM: "quantum_fourier_transform.schema.json",
     JobType.LR_QAOA: "lr_qaoa.schema.json",
+    JobType.Q_GRADE: "q_grade.schema.json",
 }

--- a/metriq_gym/registry.py
+++ b/metriq_gym/registry.py
@@ -14,6 +14,7 @@ from metriq_gym.benchmarks.wit import WIT, WITData, WITResult
 from metriq_gym.benchmarks.qedc_benchmarks import QEDCBenchmark, QEDCData, QEDCResult
 from metriq_gym.benchmarks.lr_qaoa import LinearRampQAOA, LinearRampQAOAData, LinearRampQAOAResult
 from metriq_gym.benchmarks.eplg import EPLG, EPLGData, EPLGResult
+from metriq_gym.benchmarks.q_grade import QGrade, QGradeData, QGradeResult
 
 BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.BSEQ: BSEQ,
@@ -27,6 +28,7 @@ BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.HIDDEN_SHIFT: QEDCBenchmark,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCBenchmark,
     JobType.LR_QAOA: LinearRampQAOA,
+    JobType.Q_GRADE: QGrade,
 }
 
 BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
@@ -41,6 +43,7 @@ BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
     JobType.HIDDEN_SHIFT: QEDCData,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCData,
     JobType.LR_QAOA: LinearRampQAOAData,
+    JobType.Q_GRADE: QGradeData,
 }
 
 BENCHMARK_RESULT_CLASSES: dict[JobType, type[BenchmarkResult]] = {
@@ -55,6 +58,7 @@ BENCHMARK_RESULT_CLASSES: dict[JobType, type[BenchmarkResult]] = {
     JobType.HIDDEN_SHIFT: QEDCResult,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCResult,
     JobType.LR_QAOA: LinearRampQAOAResult,
+    JobType.Q_GRADE: QGradeResult,
 }
 
 

--- a/metriq_gym/schemas/examples/q_grade.example.json
+++ b/metriq_gym/schemas/examples/q_grade.example.json
@@ -1,0 +1,5 @@
+{
+  "benchmark_name": "Q-Grade",
+  "ring_sizes": [4, 6, 8, 10, 12],
+  "shots": 1000
+}

--- a/metriq_gym/schemas/q_grade.schema.json
+++ b/metriq_gym/schemas/q_grade.schema.json
@@ -1,0 +1,53 @@
+{
+    "$id": "metriq-gym/q_grade.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Many-body coherence grade (Q-Grade)",
+    "description": "The Q-Grade benchmark schema definition, describing the many-body quantum coherence grade via anyon interference in a Trotterised Ising ring with twisted boundary conditions (Teng et al., arXiv:2503.12573, 2025). For each ring size two circuits are submitted (with and without a vison) and the contrast R_gamma is measured. The Q-grade is the largest ring size for which R_gamma meets the threshold.",
+    "type": "object",
+    "properties": {
+      "benchmark_name": {
+        "type": "string",
+        "const": "Q-Grade",
+        "description": "Name of the benchmark. Must be 'Q-Grade' for this schema."
+      },
+      "ring_sizes": {
+        "type": "array",
+        "description": "Even ring sizes (at least 4) to test. Two circuits are submitted per ring size: one with a vison on the ring, one without.",
+        "items": {
+          "type": "integer",
+          "minimum": 4,
+          "multipleOf": 2
+        },
+        "minItems": 1,
+        "uniqueItems": true,
+        "default": [4, 6, 8, 10, 12],
+        "examples": [[4, 6, 8, 10, 12]]
+      },
+      "shots": {
+        "type": "integer",
+        "description": "Number of measurement shots (repetitions) to use per circuit.",
+        "default": 1000,
+        "minimum": 1,
+        "examples": [1000]
+      },
+      "j_coupling": {
+        "type": "number",
+        "description": "Ising coupling strength J (reference energy). Fixed to 1.0 in the paper.",
+        "default": 1.0
+      },
+      "gamma_hopping": {
+        "type": "number",
+        "description": "Transverse-field strength Gamma, setting the spinon hopping rate. The paper uses 0.1 (<< J).",
+        "default": 0.1,
+        "exclusiveMinimum": 0.0
+      },
+      "threshold": {
+        "type": "number",
+        "description": "R_gamma threshold used to define the Q-grade. The paper uses 0.2.",
+        "default": 0.2,
+        "minimum": 0.0,
+        "maximum": 1.0
+      }
+    },
+    "required": ["benchmark_name"]
+  }


### PR DESCRIPTION
## Description

Adds the Q-Grade benchmark from Teng et al., "Standardized test of many-body
coherence in gate-based quantum platforms" (arXiv:2503.12573, 2025).

Q-Grade measures many-body quantum coherence via anyon interference in a
Trotterised Ising ring with twisted boundary conditions. For each ring size,
it submits two circuits (with and without a vison through the ring) and
reports the largest ring size at which the spinon-blockade contrast R_gamma
clears a configurable threshold (default 0.2).

## Type of change

**New:**
- `metriq_gym/benchmarks/q_grade.py` — benchmark implementation
- `metriq_gym/schemas/q_grade.schema.json` — config schema
- `metriq_gym/schemas/examples/q_grade.example.json` — example config

**Modified:**
- `metriq_gym/constants.py` — added `JobType.Q_GRADE` and schema mapping entry
- `metriq_gym/registry.py` — registered `QGrade` / `QGradeData` / `QGradeResult`

## Testing

Verified end-to-end on the local Aer simulator:
mgym job dispatch metriq_gym/schemas/examples/q_grade.example.json -p local -d aer_simulator
mgym job poll <id>

Reports `q_grade = 12` (the max of the tested `ring_sizes`) with
`r_gamma ≈ 1.00 ± 0.01`, as expected on a noiseless simulator.

## Notes

During local testing I hit an unrelated import bug in
`metriq_gym/benchmarks/qedc_benchmarks.py` (`from _common import metrics` —
the module path resolution fails). This is not related to Q-Grade and I will
open a separate issue for it.