### PR TITLE
Enable fork-safe documentation previews

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,30 @@
+name: Cleanup Documentation Preview
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write preview metadata
+        run: |
+          mkdir -p preview-metadata
+          printf '%s\n' "${{ github.event.pull_request.number }}" > preview-metadata/pr-number.txt
+          printf '%s\n' "${{ github.event.action }}" > preview-metadata/pr-action.txt
+
+      - name: Upload preview metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: docs-preview-metadata
+          path: preview-metadata/
+          retention-days: 3

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -1,0 +1,109 @@
+name: Deploy Documentation Preview
+
+on:
+  workflow_run:
+    workflows:
+      - Build Documentation Preview
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: preview-deploy-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download preview metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name docs-preview-metadata \
+            --dir preview-metadata
+
+      - name: Read and validate preview metadata
+        id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr_number="$(cat preview-metadata/pr-number.txt)"
+          pr_action="$(cat preview-metadata/pr-action.txt)"
+
+          case "$pr_number" in
+            ''|*[!0-9]*)
+              echo "Invalid PR number in preview metadata: $pr_number" >&2
+              exit 1
+              ;;
+          esac
+
+          case "$pr_action" in
+            opened|reopened|synchronize|closed)
+              ;;
+            *)
+              echo "Invalid PR action in preview metadata: $pr_action" >&2
+              exit 1
+              ;;
+          esac
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")"
+          pr_head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
+          pr_merge_sha="$(jq -r '.merge_commit_sha // empty' <<< "$pr_json")"
+
+          if [ "$pr_head_sha" != "$RUN_HEAD_SHA" ] && [ "$pr_merge_sha" != "$RUN_HEAD_SHA" ]; then
+            echo "Preview metadata does not match workflow run head SHA." >&2
+            echo "PR head SHA: $pr_head_sha" >&2
+            echo "PR merge SHA: $pr_merge_sha" >&2
+            echo "Run head SHA: $RUN_HEAD_SHA" >&2
+            exit 1
+          fi
+
+          {
+            echo "pr_number=$pr_number"
+            echo "pr_action=$pr_action"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download built documentation
+        if: ${{ steps.metadata.outputs.pr_action != 'closed' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name docs-preview-site \
+            --dir docs-site
+
+      - name: Deploy preview
+        if: ${{ steps.metadata.outputs.pr_action != 'closed' }}
+        uses: rossjrw/pr-preview-action@v1.8.1
+        with:
+          source-dir: docs-site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+          pr-number: ${{ steps.metadata.outputs.pr_number }}
+          deploy-commit-message: Deploy preview for PR ${{ steps.metadata.outputs.pr_number }}
+
+      - name: Remove preview
+        if: ${{ steps.metadata.outputs.pr_action == 'closed' }}
+        uses: rossjrw/pr-preview-action@v1.8.1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove
+          pr-number: ${{ steps.metadata.outputs.pr_number }}
+          remove-commit-message: Remove preview for PR ${{ steps.metadata.outputs.pr_number }}

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - Build Documentation Preview
+      - Cleanup Documentation Preview
     types:
       - completed
 
@@ -22,7 +23,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Download preview metadata
         env:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,36 +1,58 @@
-name: Deploy Documentation Preview
+name: Build Documentation Preview
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
     paths:
       - 'docs/**'
       - 'metriq_gym/**'
       - '.github/workflows/docs-preview.yml'
+      - '.github/workflows/docs-preview-deploy.yml'
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
-  group: preview-${{ github.ref }}
+  group: preview-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  preview:
+  build:
     runs-on: ubuntu-latest
     steps:
+      - name: Write preview metadata
+        run: |
+          mkdir -p preview-metadata
+          printf '%s\n' "${{ github.event.pull_request.number }}" > preview-metadata/pr-number.txt
+          printf '%s\n' "${{ github.event.action }}" > preview-metadata/pr-action.txt
+
+      - name: Upload preview metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: docs-preview-metadata
+          path: preview-metadata/
+          retention-days: 3
+
       - uses: actions/checkout@v6
+        if: ${{ github.event.action != 'closed' }}
 
       - name: Set up Python
+        if: ${{ github.event.action != 'closed' }}
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install dependencies
+        if: ${{ github.event.action != 'closed' }}
         run: |
           pip install mkdocs mkdocs-material mkdocstrings[python]
 
       - name: Build documentation
+        if: ${{ github.event.action != 'closed' }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -39,10 +61,10 @@ jobs:
           sed -i "s|site_url:.*|site_url: https://unitaryfoundation.github.io/metriq-gym/pr-preview/pr-${PR_NUMBER}/|" mkdocs.yml
           mkdocs build
 
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1.8.1
+      - name: Upload built documentation
+        if: ${{ github.event.action != 'closed' }}
+        uses: actions/upload-artifact@v6
         with:
-          source-dir: docs/site
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          action: deploy
+          name: docs-preview-site
+          path: docs/site/
+          retention-days: 3

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         if: ${{ github.event.action != 'closed' }}
         run: |
-          pip install mkdocs mkdocs-material mkdocstrings[python]
+          pip install .[docs]
 
       - name: Build documentation
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -6,7 +6,12 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
+    paths:
+      - 'docs/**'
+      - 'metriq_gym/**'
+      - 'pyproject.toml'
+      - '.github/workflows/docs-preview.yml'
+      - '.github/workflows/docs-preview-deploy.yml'
 
 permissions:
   contents: read
@@ -33,21 +38,17 @@ jobs:
           retention-days: 3
 
       - uses: actions/checkout@v7
-        if: ${{ github.event.action != 'closed' }}
-      
+
       - name: Set up Python
-        if: ${{ github.event.action != 'closed' }}
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        if: ${{ github.event.action != 'closed' }}
         run: |
-          pip install .[docs]
+          pip install ".[docs]"
 
       - name: Build documentation
-        if: ${{ github.event.action != 'closed' }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -57,7 +58,6 @@ jobs:
           mkdocs build
 
       - name: Upload built documentation
-        if: ${{ github.event.action != 'closed' }}
         uses: actions/upload-artifact@v6
         with:
           name: docs-preview-site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,14 +27,17 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install .[docs]
+        run: pip install ".[docs]"
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Deploy to GitHub Pages
+      - name: Build documentation
         run: |
           cd docs
-          mkdocs gh-deploy --force
+          mkdocs build
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs/site
+          clean-exclude: pr-preview
+          force: false


### PR DESCRIPTION
# Description

The documentation preview action is failing on PRs from forks by authors that don't have write access to the repo, e.g.
https://github.com/unitaryfoundation/metriq-gym/actions/runs/24612447029/job/71969063228?pr=741 from PR #741 

The PR workflow now builds the docs with read-only permissions and uploads the generated site as an artifact. A separate workflow then validates the PR metadata and deploys the artifact to the `gh-pages` preview path with the required write permissions.

[Mostly coded by Codex with ChatGPT 5.5]

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hard to test locally. However, after merging, we can rebase main into PR #741 and see if it works.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
