### PR TITLE
feat(benchmarks): add two-qubit gate count fields to benchmark data (#715)

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,9 +1,9 @@
 import argparse
-from typing import Iterable, TYPE_CHECKING, Protocol
+from dataclasses import dataclass
+from typing import Iterable, TYPE_CHECKING, Protocol, runtime_checkable
 from abc import ABC
 
 from pydantic import BaseModel, computed_field
-from dataclasses import dataclass
 
 
 if TYPE_CHECKING:
@@ -11,22 +11,37 @@ if TYPE_CHECKING:
     from metriq_gym.resource_estimation import CircuitBatch
 
 
+@runtime_checkable
 class SupportsId(Protocol):
+    """Protocol for objects that have an `id` attribute (e.g., QuantumJob)."""
+
     id: str
 
 
 def flatten_job_ids(job: SupportsId | Iterable[SupportsId]) -> list[str]:
-    """Return provider job IDs from a single job or an iterable of jobs."""
+    """Return provider job IDs from a single job or an iterable of jobs.
+
+    Raises:
+        TypeError: If the job is neither a SupportsId nor an iterable of SupportsId.
+    """
+    if isinstance(job, SupportsId):
+        return [job.id]
     if isinstance(job, Iterable) and not isinstance(job, (str, bytes)):
-        return [job.id for job in job]
-    return [job.id]
+        return [j.id for j in job]
+    raise TypeError(f"flatten_job_ids: unsupported job type {type(job).__name__}")
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BenchmarkData:
-    """Stores intermediate data from pre-processing and dispatching"""
+    """Stores intermediate data from pre-processing and dispatching.
 
-    provider_job_ids: list[str]
+    Subclasses declare their own required fields first. The three inherited fields
+    below are keyword-only with default None when not provided.
+    """
+
+    input_two_qubit_gate_counts: list[int] | None = None
+    transpiled_two_qubit_gate_counts: list[int] | None = None
+    provider_job_ids: list[str] | None = None
 
     @classmethod
     def from_quantum_job(cls, quantum_job, **kwargs):

--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -50,7 +50,7 @@ from metriq_gym.helpers.graph_helpers import (
     largest_connected_size,
 )
 from metriq_gym.qplatform.device import connectivity_graph
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -207,14 +207,14 @@ class BSEQ(Benchmark):
             device.run(circ_set, shots=shots) for circ_set in circuit_sets
         ]
 
-        provider_job_ids = [
-            job.id
-            for quantum_job_set in quantum_jobs
-            for job in (quantum_job_set if isinstance(quantum_job_set, list) else [quantum_job_set])
+        # Count 2Q gates per circuit set (one entry per color group)
+        input_two_qubit_gate_counts = [
+            sum(count_gates(c).two_qubit for c in circ_set)
+            for circ_set in circuit_sets
         ]
 
-        return BSEQData(
-            provider_job_ids=provider_job_ids,
+        return BSEQData.from_quantum_job(
+            quantum_jobs,
             shots=shots,
             num_qubits=device.num_qubits,
             topology_graph=topology_graph,
@@ -223,6 +223,8 @@ class BSEQ(Benchmark):
                 "edge_color_map": dict(coloring.edge_color_map),
                 "edge_index_map": dict(coloring.edge_index_map),
             },
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     def poll_handler(

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -47,7 +47,7 @@ from metriq_gym.qplatform.device import (
     connectivity_graph_for_gate,
     pruned_connectivity_graph,
 )
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -390,13 +390,20 @@ class Clops(Benchmark):
         circuits = instantiate_circuits(
             template, parameters, self.params.num_circuits, seed=self.params.seed
         )
+        input_two_qubit_gate_counts = [count_gates(c).two_qubit for c in circuits]
         if isinstance(device, QiskitBackend) and self.params.use_session:
             return ClopsData.from_quantum_job(
                 self._submit_ibm_with_options(
                     device, circuits, shots=self.params.shots, use_session=self.params.use_session
-                )
+                ),
+                input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+                transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
             )
-        return ClopsData.from_quantum_job(device.run(circuits, shots=self.params.shots))
+        return ClopsData.from_quantum_job(
+            device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
+        )
 
     def _dispatch_parameterized(self, device: QiskitBackend) -> ClopsData:
         """Send a single parameterized circuit with parameter arrays.
@@ -414,8 +421,11 @@ class Clops(Benchmark):
         ]
 
         pub = (template, param_values, self.params.shots)
+        input_two_qubit_gate_counts = [count_gates(template).two_qubit] * self.params.num_circuits
         return ClopsData.from_quantum_job(
-            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session)
+            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     def _dispatch_twirled(self, device: QiskitBackend) -> ClopsData:
@@ -433,6 +443,7 @@ class Clops(Benchmark):
             shots_per_randomization=self.params.shots,
             enable_gates=True,
         )
+        input_two_qubit_gate_counts = [count_gates(template).two_qubit] * self.params.num_circuits
         return ClopsData.from_quantum_job(
             self._submit_ibm_with_options(
                 device,
@@ -440,7 +451,9 @@ class Clops(Benchmark):
                 shots=self.params.shots * self.params.num_circuits,
                 twirling_options=twirling_opts,
                 use_session=self.params.use_session,
-            )
+            ),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     # ------------------------------------------------------------------

--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -39,7 +39,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
 )
 from metriq_gym.qplatform.device import connectivity_graph, connectivity_graph_for_gate
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -313,7 +313,9 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def _build_circuits(
         self, device: "QuantumDevice"
-    ) -> tuple[list, list[int], list[list[tuple[int, int]]], str, list[str]]:
+    ) -> tuple[
+        list, list, list[int], list[list[tuple[int, int]]], str, list[str]
+    ]:
         """Build LayerFidelity circuits.
 
         Returns:
@@ -356,24 +358,40 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
         )
 
         lfexp.experiment_options.max_circuits = 2 * num_samples * len(lengths)
+        input_circuits = lfexp.circuits()
         if self.params.decompose_clifford_ops:
-            circuits = lfexp._transpiled_circuits()
+            transpiled_circuits = lfexp._transpiled_circuits()
         else:
-            circuits = lfexp.circuits()
+            transpiled_circuits = input_circuits
 
-        return circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates
+        return (
+            input_circuits,
+            transpiled_circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+        )
 
     def dispatch_handler(self, device: "QuantumDevice") -> EPLGData:
         """Generate circuits, submit to device, return EPLGData."""
-        circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates = (
+        input_circuits, transpiled_circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates = (
             self._build_circuits(device)
         )
 
         shots = self.params.shots
-        quantum_job = device.run(circuits, shots=shots)
+        quantum_job = device.run(transpiled_circuits, shots=shots)
 
         # Serialize the two_disjoint_layers as nested lists
         serialized_layers = [[list(edge) for edge in layer] for layer in two_disjoint_layers]
+
+        # Count 2Q gates for both input and transpiled circuits
+        input_two_qubit_gate_counts = [
+            count_gates(c).two_qubit for c in input_circuits
+        ]
+        transpiled_two_qubit_gate_counts = [
+            count_gates(c).two_qubit for c in transpiled_circuits
+        ]
 
         return EPLGData.from_quantum_job(
             quantum_job,
@@ -386,6 +404,8 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
             seed=self.params.seed,
             two_qubit_gate=two_qubit_gate,
             one_qubit_basis_gates=one_qubit_basis_gates,
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=transpiled_two_qubit_gate_counts,
         )
 
     def poll_handler(
@@ -478,5 +498,5 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def estimate_resources_handler(self, device: "QuantumDevice") -> list[CircuitBatch]:
         """Return circuit batches for resource estimation."""
-        circuits, _, _, _, _ = self._build_circuits(device)
-        return [CircuitBatch(circuits=circuits, shots=self.params.shots)]
+        _, transpiled_circuits, _, _, _, _ = self._build_circuits(device)
+        return [CircuitBatch(circuits=transpiled_circuits, shots=self.params.shots)]

--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -45,7 +45,7 @@ from metriq_gym.benchmarks.benchmark import (
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.qplatform.device import connectivity_graph
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -170,7 +170,6 @@ def calc_random_stats(num_qubits, graph_info, shots, num_random_trials, optimal_
 
 @dataclass
 class LinearRampQAOAData(BenchmarkData):
-    provider_job_ids: list[str]
     num_qubits: int
     graph_info: list[list]
     graph_type: GraphType
@@ -439,6 +438,7 @@ class LinearRampQAOA(Benchmark):
         circuits_with_params, graph_info, optimal_sol, circuit_encoding = self._build_circuits(
             device
         )
+        input_two_qubit_gate_counts = [count_gates(c).two_qubit for c in circuits_with_params]
 
         approx_ratio_random_mean, approx_ratio_random_std = calc_random_stats(
             self.params.num_qubits,
@@ -465,6 +465,8 @@ class LinearRampQAOA(Benchmark):
             circuit_encoding=circuit_encoding,
             approx_ratio_random_mean=approx_ratio_random_mean,
             approx_ratio_random_std=approx_ratio_random_std,
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     def poll_handler(

--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -43,7 +43,7 @@ from metriq_gym.qplatform.device import connectivity_graph
 
 from typing import TYPE_CHECKING
 
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -71,8 +71,8 @@ class MirrorCircuitsData(BenchmarkData):
     shots: int
     num_qubits: int
     num_circuits: int
-    seed: int | None
     expected_bitstrings: list[str]
+    seed: int | None = None
 
 
 POLARIZATION_THRESHOLD = 1 / np.e
@@ -557,6 +557,7 @@ class MirrorCircuits(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> MirrorCircuitsData:
         circuits, expected_bitstrings, actual_width = self._build_circuits(device)
+        input_two_qubit_gate_counts = [count_gates(c).two_qubit for c in circuits]
 
         return MirrorCircuitsData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),
@@ -568,6 +569,8 @@ class MirrorCircuits(Benchmark):
             num_circuits=self.params.num_circuits,
             seed=self.params.seed,
             expected_bitstrings=expected_bitstrings,
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     def poll_handler(

--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -32,7 +32,7 @@ from metriq_gym.benchmarks.benchmark import (
 )
 from metriq_gym.constants import JobType
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 from _common import metrics
 
@@ -295,11 +295,14 @@ class QEDCBenchmark(Benchmark):
     def dispatch_handler(self, device: "QuantumDevice") -> QEDCData:
         # For more information on the parameters, view the schema for this benchmark.
         circuits, circuit_metrics, circuit_identifiers = self._build_circuits(device)
+        input_two_qubit_gate_counts = [count_gates(c).two_qubit for c in circuits]
 
         return QEDCData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),
             circuit_metrics=circuit_metrics,
             circuit_identifiers=circuit_identifiers,
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     def poll_handler(

--- a/metriq_gym/benchmarks/qml_kernel.py
+++ b/metriq_gym/benchmarks/qml_kernel.py
@@ -30,7 +30,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkScore,
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -118,7 +118,12 @@ class QMLKernel(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> QMLKernelData:
         circuit = self._build_circuits(device)
-        return QMLKernelData.from_quantum_job(device.run(circuit, shots=self.params.shots))
+        input_two_qubit_gate_counts = [count_gates(circuit).two_qubit]
+        return QMLKernelData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
+        )
 
     def poll_handler(
         self,

--- a/metriq_gym/benchmarks/wit.py
+++ b/metriq_gym/benchmarks/wit.py
@@ -34,7 +34,7 @@ from metriq_gym.helpers.statistics import (
     binary_expectation_stddev,
     binary_expectation_value,
 )
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, count_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -260,7 +260,12 @@ class WIT(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> WITData:
         circuit = self._build_circuits(device)
-        return WITData.from_quantum_job(device.run(circuit, shots=self.params.shots))
+        input_two_qubit_gate_counts = [count_gates(circuit).two_qubit]
+        return WITData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
+        )
 
     def poll_handler(
         self,

--- a/metriq_gym/resource_estimation.py
+++ b/metriq_gym/resource_estimation.py
@@ -77,6 +77,21 @@ def _count_gates(circuit: QuantumCircuit) -> GateCounts:
     return counts
 
 
+def count_gates(circuit: QuantumCircuit) -> GateCounts:
+    """Count the number of gates in a quantum circuit by qubit count.
+
+    This is the public wrapper around the internal _count_gates function.
+
+    Args:
+        circuit: The quantum circuit to analyze.
+
+    Returns:
+        A GateCounts namedtuple with one_qubit, two_qubit, multi_qubit,
+        measurements, and resets counts.
+    """
+    return _count_gates(circuit)
+
+
 HQCFunction = Callable[[GateCounts, int, int], float]
 
 

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -757,7 +757,7 @@ def fetch_result(
 
     quantum_jobs = [
         (load_job(job_id, provider=metriq_job.provider_name, **asdict(job_data)))
-        for job_id in job_data.provider_job_ids
+        for job_id in (job_data.provider_job_ids or [])
     ]
     if all(task.status() == JobStatus.COMPLETED for task in quantum_jobs):
         result_data = [task.result().data for task in quantum_jobs]

--- a/tests/unit/benchmarks/test_gate_counts.py
+++ b/tests/unit/benchmarks/test_gate_counts.py
@@ -1,0 +1,408 @@
+"""Unit tests for 2Q gate count tracking in BenchmarkData.
+
+Tests the feature added in issue #715:
+- input_two_qubit_gate_counts: one entry per input circuit
+- transpiled_two_qubit_gate_counts: one entry per transpiled circuit
+"""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import rustworkx as rx
+
+from metriq_gym.benchmarks.benchmark import BenchmarkData
+
+
+class TestBenchmarkDataGateCounts:
+    """Test that BenchmarkData correctly stores 2Q gate count fields."""
+
+    def test_base_benchmark_data_defaults_to_none(self):
+        """New fields default to None when not provided."""
+        data = BenchmarkData(provider_job_ids=["job-1"])
+        assert data.input_two_qubit_gate_counts is None
+        assert data.transpiled_two_qubit_gate_counts is None
+
+    def test_base_benchmark_data_stores_gate_counts(self):
+        """Can set gate count fields explicitly."""
+        data = BenchmarkData(
+            provider_job_ids=["job-1"],
+            input_two_qubit_gate_counts=[1, 2, 3],
+            transpiled_two_qubit_gate_counts=[2, 4, 6],
+        )
+        assert data.input_two_qubit_gate_counts == [1, 2, 3]
+        assert data.transpiled_two_qubit_gate_counts == [2, 4, 6]
+
+    def test_from_quantum_job_preserves_gate_counts(self):
+        """from_quantum_job() passes through gate count kwargs."""
+        mock_job = MagicMock()
+        mock_job.id = "job-test"
+
+        data = BenchmarkData.from_quantum_job(
+            mock_job,
+            input_two_qubit_gate_counts=[5, 10],
+            transpiled_two_qubit_gate_counts=[7, 14],
+        )
+        assert data.provider_job_ids == ["job-test"]
+        assert data.input_two_qubit_gate_counts == [5, 10]
+        assert data.transpiled_two_qubit_gate_counts == [7, 14]
+
+
+class TestCLOPSGateCounts:
+    """Test CLOPS (non-transpiling) benchmark populates gate counts correctly."""
+
+    def _linear_graph(self, n: int) -> rx.PyGraph:
+        g = rx.PyGraph()
+        g.add_nodes_from(range(n))
+        for i in range(n - 1):
+            g.add_edge(i, i + 1, None)
+        return g
+
+    def _make_params(self, **overrides):
+        defaults = dict(
+            benchmark_name="CLOPS",
+            num_qubits=4,
+            num_layers=2,
+            num_circuits=3,
+            shots=10,
+            seed=42,
+            two_qubit_gate="cz",
+            mode="instantiated",
+        )
+        defaults.update(overrides)
+        m = MagicMock()
+        for k, v in defaults.items():
+            setattr(m, k, v)
+        return m
+
+    def _make_clops(self, **param_overrides):
+        from metriq_gym.benchmarks.clops import Clops
+
+        args = argparse.Namespace()
+        params = self._make_params(**param_overrides)
+        return Clops(args, params)
+
+    def test_dispatch_instantiated_sets_gate_counts(self):
+        """CLOPS instantiated mode sets input and transpiled to same values."""
+        from metriq_gym.benchmarks.clops import ClopsData
+
+        clops = self._make_clops(mode="instantiated", use_session=False, num_circuits=3)
+        device = MagicMock()
+        device.profile.basis_gates = ["cz", "sx", "rz"]
+
+        graph = self._linear_graph(6)
+        mock_job = MagicMock()
+        mock_job.id = "job-clops"
+        device.run.return_value = mock_job
+
+        with (
+            patch(
+                "metriq_gym.benchmarks.clops.connectivity_graph_for_gate",
+                return_value=graph,
+            ),
+            patch("metriq_gym.benchmarks.clops.connectivity_graph", return_value=graph),
+            patch(
+                "metriq_gym.benchmarks.clops.pruned_connectivity_graph",
+                return_value=graph,
+            ),
+        ):
+            result = clops.dispatch_handler(device)
+
+        assert isinstance(result, ClopsData)
+        assert result.input_two_qubit_gate_counts is not None
+        assert result.transpiled_two_qubit_gate_counts is not None
+        # CLOPS doesn't transpile, so both should be identical
+        assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+        # Should have one count per circuit
+        assert len(result.input_two_qubit_gate_counts) == 3
+        # All counts should be non-negative integers
+        for count in result.input_two_qubit_gate_counts:
+            assert isinstance(count, int)
+            assert count >= 0
+
+    def test_dispatch_parameterized_sets_gate_counts(self):
+        """CLOPS parameterized mode sets gate counts on template."""
+        from metriq_gym.benchmarks.clops import ClopsData
+        from qbraid.runtime import QiskitBackend
+
+        clops = self._make_clops(mode="parameterized", num_circuits=2)
+        device = MagicMock(spec=QiskitBackend)
+        device.profile.basis_gates = ["cz", "sx", "rz"]
+
+        graph = self._linear_graph(6)
+        mock_job = MagicMock()
+        mock_job.id = "job-clops-param"
+        clops._submit_ibm_with_options = MagicMock(return_value=mock_job)
+
+        with (
+            patch(
+                "metriq_gym.benchmarks.clops.connectivity_graph_for_gate",
+                return_value=graph,
+            ),
+            patch("metriq_gym.benchmarks.clops.connectivity_graph", return_value=graph),
+            patch(
+                "metriq_gym.benchmarks.clops.pruned_connectivity_graph",
+                return_value=graph,
+            ),
+        ):
+            result = clops.dispatch_handler(device)
+
+        assert isinstance(result, ClopsData)
+        assert result.input_two_qubit_gate_counts is not None
+        assert result.transpiled_two_qubit_gate_counts is not None
+        assert len(result.input_two_qubit_gate_counts) == 2
+        # Parameterized sends same template for all circuits
+        assert (
+            result.input_two_qubit_gate_counts[0]
+            == result.input_two_qubit_gate_counts[1]
+        )
+
+    def test_dispatch_twirled_sets_gate_counts(self):
+        """CLOPS twirled mode sets gate counts on fixed template."""
+        from metriq_gym.benchmarks.clops import ClopsData
+        from qbraid.runtime import QiskitBackend
+
+        clops = self._make_clops(mode="twirled", num_circuits=5)
+        device = MagicMock(spec=QiskitBackend)
+        device.profile.basis_gates = ["cz", "sx", "rz"]
+
+        graph = self._linear_graph(6)
+        mock_job = MagicMock()
+        mock_job.id = "job-clops-twirled"
+        clops._submit_ibm_with_options = MagicMock(return_value=mock_job)
+
+        with (
+            patch(
+                "metriq_gym.benchmarks.clops.connectivity_graph_for_gate",
+                return_value=graph,
+            ),
+            patch("metriq_gym.benchmarks.clops.connectivity_graph", return_value=graph),
+            patch(
+                "metriq_gym.benchmarks.clops.pruned_connectivity_graph",
+                return_value=graph,
+            ),
+        ):
+            result = clops.dispatch_handler(device)
+
+        assert isinstance(result, ClopsData)
+        assert len(result.input_two_qubit_gate_counts) == 5
+        assert (
+            result.input_two_qubit_gate_counts
+            == result.transpiled_two_qubit_gate_counts
+        )
+
+
+class TestEPLGGateCounts:
+    """Test EPLG (transpiling) benchmark populates both gate count fields."""
+
+    def _make_eplg_params(self, **overrides):
+        defaults = dict(
+            benchmark_name="EPLG",
+            num_qubits_in_chain=5,
+            lengths=[4, 8],
+            num_samples=2,
+            shots=100,
+            seed=42,
+            two_qubit_gate="cx",
+            one_qubit_basis_gates=["sx", "rz"],
+            decompose_clifford_ops=True,
+            constrain_rb_offset_b=False,
+        )
+        defaults.update(overrides)
+        m = MagicMock()
+        for k, v in defaults.items():
+            setattr(m, k, v)
+        return m
+
+    def _make_eplg(self, **param_overrides):
+        from metriq_gym.benchmarks.eplg import EPLG
+
+        args = argparse.Namespace()
+        params = self._make_eplg_params(**param_overrides)
+        return EPLG(args, params)
+
+    def test_dispatch_sets_both_gate_count_fields(self):
+        """EPLG dispatch populates both input and transpiled gate counts."""
+        from metriq_gym.benchmarks.eplg import EPLGData
+
+        eplg = self._make_eplg(decompose_clifford_ops=True)
+        device = MagicMock()
+        device.num_qubits = 10
+        mock_job = MagicMock()
+        mock_job.id = "job-eplg"
+
+        graph = rx.generators.path_graph(10)
+        device.run.return_value = mock_job
+
+        with (
+            patch(
+                "metriq_gym.benchmarks.eplg.connectivity_graph_for_gate",
+                return_value=graph,
+            ),
+            patch("metriq_gym.benchmarks.eplg.connectivity_graph", return_value=graph),
+        ):
+            result = eplg.dispatch_handler(device)
+
+        assert isinstance(result, EPLGData)
+        assert result.input_two_qubit_gate_counts is not None
+        assert result.transpiled_two_qubit_gate_counts is not None
+        # Both should have same length (one per circuit)
+        assert len(result.input_two_qubit_gate_counts) == len(
+            result.transpiled_two_qubit_gate_counts
+        )
+        # Transpiled circuits should have >= total 2Q gates than input
+        # (decomposition expands Clifford ops into native gates)
+        assert sum(result.transpiled_two_qubit_gate_counts) >= sum(
+            result.input_two_qubit_gate_counts
+        )
+
+    def test_dispatch_without_decompose_mirrors_counts(self):
+        """EPLG without decompose_clifford_ops mirrors input=transpiled."""
+        from metriq_gym.benchmarks.eplg import EPLGData
+
+        eplg = self._make_eplg(decompose_clifford_ops=False)
+        device = MagicMock()
+        device.num_qubits = 10
+        mock_job = MagicMock()
+        mock_job.id = "job-eplg-no-decomp"
+
+        graph = rx.generators.path_graph(10)
+        device.run.return_value = mock_job
+
+        with (
+            patch(
+                "metriq_gym.benchmarks.eplg.connectivity_graph_for_gate",
+                return_value=graph,
+            ),
+            patch("metriq_gym.benchmarks.eplg.connectivity_graph", return_value=graph),
+        ):
+            result = eplg.dispatch_handler(device)
+
+        assert isinstance(result, EPLGData)
+        assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+
+
+class TestWITGateCounts:
+    """Test WIT (non-transpiling) benchmark gate counts mirror input=transpiled."""
+
+    def _make_wit_params(self, **overrides):
+        defaults = dict(benchmark_name="WIT", num_qubits=6, shots=100)
+        defaults.update(overrides)
+        m = MagicMock()
+        for k, v in defaults.items():
+            setattr(m, k, v)
+        return m
+
+    def _make_wit(self, **param_overrides):
+        from metriq_gym.benchmarks.wit import WIT
+
+        args = argparse.Namespace()
+        params = self._make_wit_params(**param_overrides)
+        return WIT(args, params)
+
+    def test_dispatch_sets_gate_counts_mirrored(self):
+        """WIT sets input=transpiled since it doesn't transpile."""
+        from metriq_gym.benchmarks.wit import WITData
+
+        wit = self._make_wit()
+        device = MagicMock()
+        mock_job = MagicMock()
+        mock_job.id = "job-wit"
+        device.run.return_value = mock_job
+
+        result = wit.dispatch_handler(device)
+
+        assert isinstance(result, WITData)
+        assert result.input_two_qubit_gate_counts is not None
+        assert result.transpiled_two_qubit_gate_counts is not None
+        # WIT has a single circuit
+        assert len(result.input_two_qubit_gate_counts) == 1
+        assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+        # WIT uses cx, swap, rzz gates - should have non-zero 2Q gate count
+        assert result.input_two_qubit_gate_counts[0] > 0
+
+
+class TestQMLKernelGateCounts:
+    """Test QMLKernel benchmark gate counts mirror input=transpiled."""
+
+    def _make_qml_kernel_params(self, **overrides):
+        defaults = dict(benchmark_name="QMLKernel", num_qubits=4, shots=100)
+        defaults.update(overrides)
+        m = MagicMock()
+        for k, v in defaults.items():
+            setattr(m, k, v)
+        return m
+
+    def _make_qml_kernel(self, **param_overrides):
+        from metriq_gym.benchmarks.qml_kernel import QMLKernel
+
+        args = argparse.Namespace()
+        params = self._make_qml_kernel_params(**param_overrides)
+        return QMLKernel(args, params)
+
+    def test_dispatch_sets_gate_counts_mirrored(self):
+        """QMLKernel sets input=transpiled since it doesn't transpile."""
+        from metriq_gym.benchmarks.qml_kernel import QMLKernelData
+
+        qml = self._make_qml_kernel()
+        device = MagicMock()
+        mock_job = MagicMock()
+        mock_job.id = "job-qml"
+        device.run.return_value = mock_job
+
+        result = qml.dispatch_handler(device)
+
+        assert isinstance(result, QMLKernelData)
+        assert result.input_two_qubit_gate_counts is not None
+        assert result.transpiled_two_qubit_gate_counts is not None
+        assert len(result.input_two_qubit_gate_counts) == 1
+        assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+        # QML kernel uses cx gates
+        assert result.input_two_qubit_gate_counts[0] > 0
+
+
+class TestBSEQGateCounts:
+    """Test BSEQ benchmark gate counts for circuit sets (multiple per color)."""
+
+    def _make_bseq_params(self, **overrides):
+        defaults = dict(benchmark_name="BSEQ", shots=100, max_colors=None)
+        defaults.update(overrides)
+        m = MagicMock()
+        for k, v in defaults.items():
+            setattr(m, k, v)
+        return m
+
+    def _make_bseq(self, **param_overrides):
+        from metriq_gym.benchmarks.bseq import BSEQ
+
+        args = argparse.Namespace()
+        params = self._make_bseq_params(**param_overrides)
+        return BSEQ(args, params)
+
+    def test_dispatch_sets_gate_counts_per_color(self):
+        """BSEQ sets one gate count entry per color group."""
+        from metriq_gym.benchmarks.bseq import BSEQData
+
+        bseq = self._make_bseq()
+        device = MagicMock()
+        device.num_qubits = 5
+        mock_job = MagicMock()
+        mock_job.id = "job-bseq"
+        device.run.return_value = mock_job
+
+        graph = rx.generators.complete_graph(5)
+        with patch(
+            "metriq_gym.benchmarks.bseq.connectivity_graph", return_value=graph
+        ):
+            result = bseq.dispatch_handler(device)
+
+        assert isinstance(result, BSEQData)
+        assert result.input_two_qubit_gate_counts is not None
+        assert result.transpiled_two_qubit_gate_counts is not None
+        # BSEQ has one entry per color (4 basis measurements per color)
+        # For complete graph on 5 qubits: 4 colors, so 4 circuit_sets
+        # input = transpiled for BSEQ (no hardware transpilation)
+        assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+        assert len(result.input_two_qubit_gate_counts) > 0
+        # Each set should have CNOT gates (2 per edge in coloring)
+        for count in result.input_two_qubit_gate_counts:
+            assert count > 0

--- a/tests/unit/test_registry_imports.py
+++ b/tests/unit/test_registry_imports.py
@@ -1,0 +1,20 @@
+"""Verify that all benchmark modules and the registry can be imported successfully.
+
+This test would have caught dataclass field-order violations at class-creation time
+before they reached CI, since those errors surface on import rather than at runtime.
+"""
+
+
+def test_registry_imports():
+    """Import the top-level registry module, which transitively imports all benchmarks."""
+    import metriq_gym.registry  # noqa: F401
+
+    # Also smoke-test direct benchmark imports to isolate which module fails
+    import metriq_gym.benchmarks.bseq  # noqa: F401
+    import metriq_gym.benchmarks.clops  # noqa: F401
+    import metriq_gym.benchmarks.eplg  # noqa: F401
+    import metriq_gym.benchmarks.lr_qaoa  # noqa: F401
+    import metriq_gym.benchmarks.mirror_circuits  # noqa: F401
+    import metriq_gym.benchmarks.qedc_benchmarks  # noqa: F401
+    import metriq_gym.benchmarks.qml_kernel  # noqa: F401
+    import metriq_gym.benchmarks.wit  # noqa: F401


### PR DESCRIPTION
## Summary

Adds `input_two_qubit_gate_counts` and `transpiled_two_qubit_gate_counts` fields to `BenchmarkData` (and all subclasses) to track the number of two-qubit gates per circuit, both before and after transpilation.

- **`input_two_qubit_gate_counts`** (`list[int] | None`): 2Q gate counts in the original input circuits
- **`transpiled_two_qubit_gate_counts`** (`list[int] | None`): 2Q gate counts after transpilation

### Implementation details

- **EPLG** (transpiling benchmark): tracks separate input and transpiled counts via `_build_circuits`, which now returns both `input_circuits` and `transpiled_circuits`. Submits transpiled circuits to the device.
- **BSEQ, CLOPS, Mirror Circuits, LR-QAOA, WIT, QML Kernel, QEDC** (non-transpiling benchmarks): `transpiled_two_qubit_gate_counts` mirrors `input_two_qubit_gate_counts` since no explicit benchmark-level transpilation occurs

The `count_gates()` public helper from `resource_estimation.py` is used to count 2Q gates in each circuit.

### Files changed

- `metriq_gym/benchmarks/benchmark.py` — base class as `@dataclass(kw_only=True)` with inherited fields; `SupportsId` is `@runtime_checkable`; `flatten_job_ids` raises `TypeError` on unsupported types
- `metriq_gym/resource_estimation.py` — added public `count_gates()` wrapper around `_count_gates`
- `metriq_gym/benchmarks/bseq.py`, `eplg.py`, `clops.py`, `mirror_circuits.py`, `lr_qaoa.py`, `wit.py`, `qml_kernel.py`, `qedc_benchmarks.py` — dispatch handler updates; all import `count_gates` from `resource_estimation`
- `tests/unit/benchmarks/test_gate_counts.py` — 11 unit tests

### Public API note

- `MirrorCircuitsData.seed` changed from required `int` to `int | None = None` (dataclass field ordering). Any direct construction of `MirrorCircuitsData` outside the dispatch path will need to pass `seed=` explicitly.

## Test plan

- [x] All 18 unit tests pass (benchmark + gate counts)
- [ ] CI passes

Closes #715

Made with [Cursor](https://cursor.com)