### PR TITLE
fix: use local fake IBM backends without auth

### DIFF
--- a/docs/content/providers/local.md
+++ b/docs/content/providers/local.md
@@ -26,10 +26,14 @@ Common simulators include:
 
 ### IBM Noise Model Simulators
 
-Use any IBM device name (e.g., `ibm_sherbrooke`, `ibm_fez`) to run locally with that device's noise model.
+Use a supported IBM fake backend name (e.g., `ibm_sherbrooke`, `ibm_fez`) to run
+locally with that device's cached noise model.
 
 !!! note
-    Noise model simulators require valid IBM credentials to fetch the noise model, but execution is local.
+    Noise model simulators use Qiskit's local fake provider when available, so
+    common fake backends do not require IBM credentials. Devices that are not
+    included in the local fake provider may still require valid IBM credentials
+    to fetch the latest backend data.
 
 ## Usage
 
@@ -126,7 +130,7 @@ For benchmarks with multiple circuits, Aer parallelizes across available CPU cor
 
 When using `ibm_<device>` noise models:
 
-1. Metriq-Gym fetches the current noise model from IBM Quantum
+1. Metriq-Gym loads a cached fake backend when Qiskit provides one locally
 2. The model includes:
    - Single-qubit gate errors
    - Two-qubit gate errors

--- a/metriq_gym/local/provider.py
+++ b/metriq_gym/local/provider.py
@@ -6,16 +6,50 @@ from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
 from metriq_gym.local.device import LocalAerDevice
 
 
+def _normalize_device_id(device_id: str) -> str:
+    return device_id.lower().replace("-", "_")
+
+
+def _backend_name(backend) -> str:
+    name = getattr(backend, "name", "")
+    if callable(name):
+        name = name()
+    return str(name)
+
+
+def _fake_backend_aliases(backend) -> set[str]:
+    name = _normalize_device_id(_backend_name(backend))
+    if not name:
+        return set()
+
+    aliases = {name}
+    if name.startswith("fake_"):
+        suffix = name.removeprefix("fake_")
+        aliases.update({suffix, f"ibm_{suffix}"})
+
+    return aliases
+
+
 class LocalProvider(QuantumProvider):
     def __init__(self) -> None:
         super().__init__()
         self.device = LocalAerDevice(provider=self)
         self._devices: dict[str, LocalAerDevice] = {}
+        self._fake_local_backends: dict[str, object] | None = None
+
+    def _get_fake_local_backends(self) -> dict[str, object]:
+        if self._fake_local_backends is None:
+            self._fake_local_backends = {}
+            for backend in FakeProviderForBackendV2().backends():
+                for alias in _fake_backend_aliases(backend):
+                    self._fake_local_backends[alias] = backend
+
+        return self._fake_local_backends
 
     def get_devices(self, **_) -> list[QuantumDevice]:
         devices = [self.device]
 
-        # Try to get all available IBM fake backends.
+        # Try to get all available IBM runtime backends.
         try:
             service = QiskitRuntimeService()
             backends = service.backends()
@@ -46,9 +80,10 @@ class LocalProvider(QuantumProvider):
             # Try loading a local fake backend first, which doesn't require an
             # IBM Quantum account, otherwise load from the runtime service.
 
-            fake_local_backends = {b.name: b for b in FakeProviderForBackendV2().backends()}
-            if device_id in fake_local_backends:
-                backend = fake_local_backends[device_id]
+            fake_local_backends = self._get_fake_local_backends()
+            normalized_device_id = _normalize_device_id(device_id)
+            if normalized_device_id in fake_local_backends:
+                backend = fake_local_backends[normalized_device_id]
             else:
                 backend = QiskitRuntimeService().backend(device_id)
             aer_backend = AerSimulator.from_backend(backend)

--- a/tests/unit/local/test_provider.py
+++ b/tests/unit/local/test_provider.py
@@ -56,18 +56,49 @@ def test_get_device_with_valid_id():
 
 def test_get_device_with_invalid_id_raises():
     provider = LocalProvider()
-    with pytest.raises(ValueError, match="Unknown device identifier"):
+    with (
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        pytest.raises(ValueError, match="Unknown device identifier"),
+    ):
+        mock_fake_provider.return_value.backends.return_value = []
+        mock_service.return_value.backend.side_effect = Exception("Not configured")
         provider.get_device("invalid_id")
+
+
+def test_get_device_with_ibm_alias_uses_local_fake_backend_without_runtime_service():
+    provider = LocalProvider()
+    fake_backend = MagicMock()
+    fake_backend.name = "fake_torino"
+
+    with (
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [fake_backend]
+        aer_backend = MagicMock()
+        mock_aer.from_backend.return_value = aer_backend
+
+        device = provider.get_device("ibm_torino")
+
+        assert isinstance(device, LocalAerDevice)
+        assert device.id == "ibm_torino"
+        mock_service.assert_not_called()
+        mock_aer.from_backend.assert_called_once_with(fake_backend)
+        assert provider.get_device("ibm_torino") is device
 
 
 def test_get_device_with_noise_model():
     provider = LocalProvider()
     with (
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
         backend = MagicMock()
         backend.name = "fake_backend"
+        mock_fake_provider.return_value.backends.return_value = []
         mock_service.return_value.backend.return_value = backend
         aer_backend = MagicMock()
         mock_aer.from_backend.return_value = aer_backend


### PR DESCRIPTION
## Summary
- Resolve IBM-style local device IDs such as `ibm_torino` against Qiskit's local fake provider before trying `QiskitRuntimeService`.
- Add aliases so cached fake backends can be addressed as `fake_torino`, `ibm_torino`, or `torino`.
- Update the local simulator docs to describe the credential-free fake-provider fallback.

## Validation
- `.\.venv\Scripts\python.exe -m pytest -q tests\unit\local\test_provider.py tests\unit\qplatform\test_device.py`
- `.\.venv\Scripts\python.exe -m ruff check metriq_gym\local\provider.py tests\unit\local\test_provider.py`
- `.\.venv\Scripts\python.exe -m ruff format --check metriq_gym\local\provider.py tests\unit\local\test_provider.py`
- Manual `LocalProvider` smoke: `ibm_torino`, `fake_torino`, `torino`, and `aer_simulator` all resolved locally.

Closes #521