### PR TITLE
Expose vendor calibration data in device metadata

### DIFF
--- a/docs/content/getting-started/metriq-platform.md
+++ b/docs/content/getting-started/metriq-platform.md
@@ -66,7 +66,15 @@ usually contains one record; suite uploads contain several.
       "device_metadata": {
         "num_qubits": 31,
         "simulator": true,
-        "version": "0.17.2"
+        "version": "0.17.2",
+        "calibration": {
+          "avg_t1_s": 0.000121,
+          "avg_t2_s": 0.000096,
+          "avg_readout_error": 0.021,
+          "avg_1q_gate_error": 0.0004,
+          "avg_2q_gate_error": 0.008,
+          "last_update_date": "2026-01-16T15:30:00+00:00"
+        }
       }
     },
     "params": {
@@ -92,7 +100,7 @@ report uncertainty on a metric use that same object shape for the metric itself.
 | `results` | Benchmark outputs. Metrics may be plain numbers or `{value, uncertainty}` objects; `results.score` is the summary score when the benchmark defines one |
 | `platform.provider` | Provider identifier used for the run |
 | `platform.device` | Device or backend identifier used for the run |
-| `platform.device_metadata` | Optional normalized metadata such as `num_qubits`, `simulator`, and backend `version` |
+| `platform.device_metadata` | Optional normalized metadata such as `num_qubits`, `simulator`, backend `version`, and vendor calibration summaries when available |
 | `params` | Validated benchmark configuration used to run the job |
 
 ## Contributing Quality Data

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -107,6 +107,30 @@ def _extend_fidelity_errors(errors: list[float], fidelities) -> None:
             errors.append(error)
 
 
+def _fidelity_type_name(fidelity) -> str | None:
+    fidelity_type = _field(fidelity, "fidelityType")
+    name = _field(fidelity_type, "name")
+    if name is None:
+        return None
+    return str(name).upper()
+
+
+def _extend_one_qubit_standardized_errors(
+    *,
+    readout_errors: list[float],
+    one_qubit_gate_errors: list[float],
+    fidelities,
+) -> None:
+    for fidelity in fidelities or []:
+        error = _error_from_fidelity(_field(fidelity, "fidelity"))
+        if error is None:
+            continue
+        if _fidelity_type_name(fidelity) == "READOUT":
+            readout_errors.append(error)
+        else:
+            one_qubit_gate_errors.append(error)
+
+
 def _set_if_present(metadata: dict, key: str, value: float | str | None) -> None:
     if value is not None:
         metadata[key] = value
@@ -218,7 +242,18 @@ def _braket_standardized_calibration(standardized) -> dict:
 
     one_qubit_properties = _field(standardized, "oneQubitProperties") or {}
     for qubit_properties in one_qubit_properties.values():
-        _extend_fidelity_errors(one_qubit_gate_errors, _field(qubit_properties, "oneQubitFidelity"))
+        _extend_one_qubit_standardized_errors(
+            readout_errors=readout_errors,
+            one_qubit_gate_errors=one_qubit_gate_errors,
+            fidelities=_field(qubit_properties, "oneQubitFidelity"),
+        )
+
+    two_qubit_properties = _field(standardized, "twoQubitProperties") or {}
+    for edge_properties in two_qubit_properties.values():
+        _extend_fidelity_errors(
+            two_qubit_gate_errors,
+            _field(edge_properties, "twoQubitGateFidelity"),
+        )
 
     return _summary_metadata(
         t1_values=t1_values,

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -1,4 +1,5 @@
 from functools import singledispatch
+import math
 from typing import cast
 
 import networkx as nx
@@ -32,6 +33,282 @@ def _(device: QiskitBackend) -> str:
 @version.register
 def _(device: LocalAerDevice) -> str:
     return device._backend.configuration().backend_version
+
+
+def _mean(values: list[float]) -> float | None:
+    finite_values = [value for value in values if math.isfinite(value)]
+    if not finite_values:
+        return None
+    return sum(finite_values) / len(finite_values)
+
+
+def _field(container, name: str, default=None):
+    if isinstance(container, dict):
+        return container.get(name, default)
+    return getattr(container, name, default)
+
+
+def _numeric_value(value) -> float | None:
+    if isinstance(value, bool) or isinstance(value, str):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _error_from_fidelity(value) -> float | None:
+    fidelity = _numeric_value(value)
+    if fidelity is None:
+        return None
+    if 0 <= fidelity <= 1:
+        return 1 - fidelity
+    if 1 < fidelity <= 100:
+        return (100 - fidelity) / 100
+    return None
+
+
+def _parameter_value(parameter, name: str) -> float | None:
+    if _field(parameter, "name") != name:
+        return None
+    return _numeric_value(_field(parameter, "value"))
+
+
+def _duration_seconds(duration) -> float | None:
+    value = _numeric_value(_field(duration, "value"))
+    if value is None:
+        return None
+    unit = _field(duration, "unit", "s")
+    unit = str(getattr(unit, "value", unit)).lower()
+    multipliers = {
+        "s": 1.0,
+        "second": 1.0,
+        "seconds": 1.0,
+        "ms": 1e-3,
+        "millisecond": 1e-3,
+        "milliseconds": 1e-3,
+        "us": 1e-6,
+        "microsecond": 1e-6,
+        "microseconds": 1e-6,
+        "ns": 1e-9,
+        "nanosecond": 1e-9,
+        "nanoseconds": 1e-9,
+    }
+    multiplier = multipliers.get(unit)
+    if multiplier is None:
+        return None
+    return value * multiplier
+
+
+def _extend_fidelity_errors(errors: list[float], fidelities) -> None:
+    for fidelity in fidelities or []:
+        error = _error_from_fidelity(_field(fidelity, "fidelity"))
+        if error is not None:
+            errors.append(error)
+
+
+def _set_if_present(metadata: dict, key: str, value: float | str | None) -> None:
+    if value is not None:
+        metadata[key] = value
+
+
+def _summary_metadata(
+    *,
+    t1_values: list[float] | None = None,
+    t2_values: list[float] | None = None,
+    readout_errors: list[float] | None = None,
+    one_qubit_gate_errors: list[float] | None = None,
+    two_qubit_gate_errors: list[float] | None = None,
+    last_update=None,
+) -> dict:
+    metadata: dict = {}
+    _set_if_present(metadata, "avg_t1_s", _mean(t1_values or []))
+    _set_if_present(metadata, "avg_t2_s", _mean(t2_values or []))
+    _set_if_present(metadata, "avg_readout_error", _mean(readout_errors or []))
+    _set_if_present(metadata, "avg_1q_gate_error", _mean(one_qubit_gate_errors or []))
+    _set_if_present(metadata, "avg_2q_gate_error", _mean(two_qubit_gate_errors or []))
+    if hasattr(last_update, "isoformat"):
+        metadata["last_update_date"] = last_update.isoformat()
+    elif isinstance(last_update, str) and last_update:
+        metadata["last_update_date"] = last_update
+    return metadata
+
+
+@singledispatch
+def calibration_metadata(device: QuantumDevice) -> dict:
+    """Return normalized vendor calibration data when a provider exposes it.
+
+    The values are intentionally aggregated to keep exported benchmark payloads
+    compact and comparable across providers.
+    """
+    return {}
+
+
+@calibration_metadata.register
+def _(device: QiskitBackend) -> dict:
+    backend = device._backend
+    if not hasattr(backend, "properties"):
+        return {}
+
+    props = backend.properties()
+    if props is None:
+        return {}
+
+    t1_values: list[float] = []
+    t2_values: list[float] = []
+    readout_errors: list[float] = []
+    for qubit_properties in getattr(props, "qubits", []) or []:
+        for parameter in qubit_properties:
+            t1 = _parameter_value(parameter, "T1")
+            if t1 is not None:
+                t1_values.append(t1)
+            t2 = _parameter_value(parameter, "T2")
+            if t2 is not None:
+                t2_values.append(t2)
+            readout_error = _parameter_value(parameter, "readout_error")
+            if readout_error is not None:
+                readout_errors.append(readout_error)
+
+    one_qubit_gate_errors: list[float] = []
+    two_qubit_gate_errors: list[float] = []
+    for gate_properties in getattr(props, "gates", []) or []:
+        gate_error = next(
+            (
+                value
+                for parameter in getattr(gate_properties, "parameters", []) or []
+                if (value := _parameter_value(parameter, "gate_error")) is not None
+            ),
+            None,
+        )
+        if gate_error is None:
+            continue
+        qubit_count = len(getattr(gate_properties, "qubits", []) or [])
+        if qubit_count == 1:
+            one_qubit_gate_errors.append(gate_error)
+        elif qubit_count == 2:
+            two_qubit_gate_errors.append(gate_error)
+
+    return _summary_metadata(
+        t1_values=t1_values,
+        t2_values=t2_values,
+        readout_errors=readout_errors,
+        one_qubit_gate_errors=one_qubit_gate_errors,
+        two_qubit_gate_errors=two_qubit_gate_errors,
+        last_update=getattr(props, "last_update_date", None),
+    )
+
+
+def _braket_standardized_calibration(standardized) -> dict:
+    t1_values: list[float] = []
+    t2_values: list[float] = []
+    readout_errors: list[float] = []
+    one_qubit_gate_errors: list[float] = []
+    two_qubit_gate_errors: list[float] = []
+
+    t1 = _duration_seconds(_field(standardized, "T1"))
+    if t1 is not None:
+        t1_values.append(t1)
+    t2 = _duration_seconds(_field(standardized, "T2"))
+    if t2 is not None:
+        t2_values.append(t2)
+
+    _extend_fidelity_errors(readout_errors, _field(standardized, "readoutFidelity"))
+    _extend_fidelity_errors(one_qubit_gate_errors, _field(standardized, "singleQubitFidelity"))
+    _extend_fidelity_errors(two_qubit_gate_errors, _field(standardized, "twoQubitGateFidelity"))
+
+    one_qubit_properties = _field(standardized, "oneQubitProperties") or {}
+    for qubit_properties in one_qubit_properties.values():
+        _extend_fidelity_errors(one_qubit_gate_errors, _field(qubit_properties, "oneQubitFidelity"))
+
+    return _summary_metadata(
+        t1_values=t1_values,
+        t2_values=t2_values,
+        readout_errors=readout_errors,
+        one_qubit_gate_errors=one_qubit_gate_errors,
+        two_qubit_gate_errors=two_qubit_gate_errors,
+        last_update=_field(standardized, "updatedAt"),
+    )
+
+
+def _braket_rigetti_calibration(provider) -> dict:
+    specs = _field(provider, "specs") or {}
+    one_qubit = specs.get("1Q", {})
+    two_qubit = specs.get("2Q", {})
+
+    t1_values = []
+    t2_values = []
+    readout_errors = []
+    one_qubit_gate_errors = []
+    two_qubit_gate_errors = []
+
+    for qubit_specs in one_qubit.values():
+        t1 = _numeric_value(_field(qubit_specs, "T1"))
+        if t1 is not None:
+            t1_values.append(t1)
+        t2 = _numeric_value(_field(qubit_specs, "T2"))
+        if t2 is not None:
+            t2_values.append(t2)
+        readout_error = _error_from_fidelity(_field(qubit_specs, "fRO"))
+        if readout_error is not None:
+            readout_errors.append(readout_error)
+        one_qubit_gate_error = _error_from_fidelity(_field(qubit_specs, "f1QRB"))
+        if one_qubit_gate_error is not None:
+            one_qubit_gate_errors.append(one_qubit_gate_error)
+
+    for gate_specs in two_qubit.values():
+        gate_error = _error_from_fidelity(_field(gate_specs, "fCZ"))
+        if gate_error is not None:
+            two_qubit_gate_errors.append(gate_error)
+
+    return _summary_metadata(
+        t1_values=t1_values,
+        t2_values=t2_values,
+        readout_errors=readout_errors,
+        one_qubit_gate_errors=one_qubit_gate_errors,
+        two_qubit_gate_errors=two_qubit_gate_errors,
+    )
+
+
+def _braket_ionq_calibration(provider) -> dict:
+    fidelity = _field(provider, "fidelity") or {}
+    readout_errors = []
+    one_qubit_gate_errors = []
+    two_qubit_gate_errors = []
+
+    one_qubit_gate_error = _error_from_fidelity(_field(fidelity.get("1Q", {}), "mean"))
+    if one_qubit_gate_error is not None:
+        one_qubit_gate_errors.append(one_qubit_gate_error)
+    two_qubit_gate_error = _error_from_fidelity(_field(fidelity.get("2Q", {}), "mean"))
+    if two_qubit_gate_error is not None:
+        two_qubit_gate_errors.append(two_qubit_gate_error)
+    readout_error = _error_from_fidelity(_field(fidelity.get("spam", {}), "mean"))
+    if readout_error is not None:
+        readout_errors.append(readout_error)
+
+    return _summary_metadata(
+        readout_errors=readout_errors,
+        one_qubit_gate_errors=one_qubit_gate_errors,
+        two_qubit_gate_errors=two_qubit_gate_errors,
+    )
+
+
+@calibration_metadata.register
+def _(device: BraketDevice) -> dict:
+    properties = getattr(device._device, "properties", None)
+    if properties is None:
+        return {}
+
+    metadata = _braket_standardized_calibration(_field(properties, "standardized"))
+    if metadata:
+        return metadata
+
+    provider = _field(properties, "provider")
+    provider_name = type(provider).__name__.lower()
+    if "rigetti" in provider_name:
+        return _braket_rigetti_calibration(provider)
+    if "ionq" in provider_name:
+        return _braket_ionq_calibration(provider)
+    return {}
 
 
 def coupling_map_to_graph(coupling_map: CouplingMap) -> rx.PyGraph:
@@ -194,6 +471,13 @@ def normalized_metadata(device: QuantumDevice) -> dict:
         ver = version(device)
         if isinstance(ver, str) and ver:
             meta["version"] = ver
+    except Exception:
+        pass
+
+    try:
+        calibration = calibration_metadata(device)
+        if calibration:
+            meta["calibration"] = calibration
     except Exception:
         pass
 

--- a/tests/unit/exporters/test_json_exporter.py
+++ b/tests/unit/exporters/test_json_exporter.py
@@ -16,3 +16,37 @@ def test_json_exporter_serializes_none_uncertainty_to_null(metriq_job, tmp_path)
 
     assert data["results"]["expectation_value"]["value"] == 0.42
     assert data["results"]["expectation_value"]["uncertainty"] is None
+
+
+def test_json_exporter_preserves_nested_device_calibration_metadata(metriq_job, tmp_path):
+    metriq_job.platform = {
+        "provider": "ibm",
+        "device": "ibm_sherbrooke",
+        "device_metadata": {
+            "version": "1.6.73",
+            "calibration": {
+                "avg_t1_s": 0.00012,
+                "avg_t2_s": 0.00009,
+                "avg_readout_error": 0.021,
+                "avg_1q_gate_error": 0.0004,
+                "avg_2q_gate_error": 0.008,
+                "last_update_date": "2026-01-16T15:30:00+00:00",
+            },
+        },
+    }
+    result = WITResult(expectation_value=BenchmarkScore(value=0.42))
+    outfile = tmp_path / "result.json"
+
+    JsonExporter(metriq_job, result).export(str(outfile))
+
+    with open(outfile) as f:
+        data = json.load(f)
+
+    assert data["platform"]["device_metadata"]["calibration"] == {
+        "avg_t1_s": 0.00012,
+        "avg_t2_s": 0.00009,
+        "avg_readout_error": 0.021,
+        "avg_1q_gate_error": 0.0004,
+        "avg_2q_gate_error": 0.008,
+        "last_update_date": "2026-01-16T15:30:00+00:00",
+    }

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -5,12 +5,15 @@ Tests the version and connectivity_graph functions for different device types
 using mocked qBraid device objects.
 """
 
+from datetime import datetime, timezone
+from decimal import Decimal
 import types
 from unittest.mock import Mock
 
 import pytest
 import rustworkx as rx
 import networkx as nx
+import numpy as np
 from qbraid.runtime import QiskitBackend, BraketDevice, AzureQuantumDevice
 
 from metriq_gym.local.provider import LocalProvider
@@ -126,6 +129,7 @@ def mock_qiskit_backend():
     mock_backend = Mock()
     mock_backend.backend_version = "1.6.73"
     mock_backend.coupling_map = MockCouplingMap(num_qubits=5)
+    mock_backend.properties.return_value = None
     device._backend = mock_backend
     return device
 
@@ -135,6 +139,7 @@ def mock_braket_device():
     device = Mock(spec=BraketDevice)
     mock_internal_device = Mock()
     mock_internal_device.topology_graph = MockTopologyGraph(num_qubits=8)
+    mock_internal_device.properties = None
     device._device = mock_internal_device
     device._provider_name = "Rigetti"
     device.num_qubits = 8
@@ -313,6 +318,87 @@ class TestNormalizedMetadata:
         assert meta.get("version") == "1.6.73"
         assert "num_qubits" not in meta
         assert "simulator" not in meta
+        assert "calibration" not in meta
+
+    def test_qiskit_backend_metadata_includes_calibration_summary(self):
+        device = Mock(spec=QiskitBackend)
+        mock_backend = Mock()
+        mock_backend.backend_version = "1.6.73"
+        mock_backend.properties.return_value = types.SimpleNamespace(
+            qubits=[
+                [
+                    types.SimpleNamespace(name="T1", value=10e-6),
+                    types.SimpleNamespace(name="T2", value=np.float64(20e-6)),
+                    types.SimpleNamespace(name="readout_error", value=Decimal("0.02")),
+                ],
+                [
+                    types.SimpleNamespace(name="T1", value=30e-6),
+                    types.SimpleNamespace(name="T2", value=40e-6),
+                    types.SimpleNamespace(name="readout_error", value=0.04),
+                ],
+            ],
+            gates=[
+                types.SimpleNamespace(
+                    qubits=[0],
+                    parameters=[types.SimpleNamespace(name="gate_error", value=0.001)],
+                ),
+                types.SimpleNamespace(
+                    qubits=[1],
+                    parameters=[types.SimpleNamespace(name="gate_error", value=0.003)],
+                ),
+                types.SimpleNamespace(
+                    qubits=[0, 1],
+                    parameters=[types.SimpleNamespace(name="gate_error", value=0.02)],
+                ),
+            ],
+            last_update_date=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+        device._backend = mock_backend
+
+        meta = normalized_metadata(device)
+
+        calibration = meta["calibration"]
+        assert meta["version"] == "1.6.73"
+        assert calibration["avg_t1_s"] == pytest.approx(20e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(30e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.03)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.002)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.02)
+        assert calibration["last_update_date"] == "2026-01-02T03:04:05+00:00"
+
+    def test_qiskit_backend_metadata_preserves_zero_calibration_values(self):
+        device = Mock(spec=QiskitBackend)
+        mock_backend = Mock()
+        mock_backend.backend_version = "1.6.73"
+        mock_backend.properties.return_value = types.SimpleNamespace(
+            qubits=[
+                [
+                    types.SimpleNamespace(name="T1", value=0.0),
+                    types.SimpleNamespace(name="T2", value=0.0),
+                    types.SimpleNamespace(name="readout_error", value=0.0),
+                ]
+            ],
+            gates=[
+                types.SimpleNamespace(
+                    qubits=[0],
+                    parameters=[types.SimpleNamespace(name="gate_error", value=0.0)],
+                ),
+                types.SimpleNamespace(
+                    qubits=[0, 1],
+                    parameters=[types.SimpleNamespace(name="gate_error", value=0.0)],
+                ),
+            ],
+            last_update_date=None,
+        )
+        device._backend = mock_backend
+
+        calibration = normalized_metadata(device)["calibration"]
+
+        assert calibration["avg_t1_s"] == 0.0
+        assert calibration["avg_t2_s"] == 0.0
+        assert calibration["avg_readout_error"] == 0.0
+        assert calibration["avg_1q_gate_error"] == 0.0
+        assert calibration["avg_2q_gate_error"] == 0.0
 
     def test_local_aer_device_metadata(self):
         provider = LocalProvider()
@@ -331,6 +417,82 @@ class TestNormalizedMetadata:
         assert meta.get("num_qubits") == 8
         assert "version" not in meta
         assert "simulator" not in meta
+
+    def test_braket_device_metadata_includes_standardized_calibration(self):
+        device = Mock(spec=BraketDevice)
+        standardized = types.SimpleNamespace(
+            T1=types.SimpleNamespace(value=120, unit="us"),
+            T2=types.SimpleNamespace(value=90, unit="us"),
+            readoutFidelity=[types.SimpleNamespace(fidelity=0.98)],
+            singleQubitFidelity=[types.SimpleNamespace(fidelity=0.997)],
+            twoQubitGateFidelity=[types.SimpleNamespace(fidelity=0.96)],
+            oneQubitProperties={
+                "0": types.SimpleNamespace(
+                    oneQubitFidelity=[types.SimpleNamespace(fidelity=0.995)]
+                ),
+                "1": types.SimpleNamespace(
+                    oneQubitFidelity=[types.SimpleNamespace(fidelity=0.993)]
+                ),
+            },
+            updatedAt=datetime(2026, 1, 16, 15, 30, tzinfo=timezone.utc),
+        )
+        device._device = types.SimpleNamespace(
+            properties=types.SimpleNamespace(standardized=standardized)
+        )
+        device.num_qubits = 2
+
+        calibration = normalized_metadata(device)["calibration"]
+
+        assert calibration["avg_t1_s"] == pytest.approx(120e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(90e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.02)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.005)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.04)
+        assert calibration["last_update_date"] == "2026-01-16T15:30:00+00:00"
+
+    def test_braket_device_metadata_includes_rigetti_provider_calibration(self):
+        class RigettiProviderProperties:
+            specs = {
+                "1Q": {
+                    "0": {"T1": 10e-6, "T2": 20e-6, "fRO": 0.91, "f1QRB": 0.991},
+                    "1": {"T1": 30e-6, "T2": 40e-6, "fRO": 0.93, "f1QRB": 0.993},
+                },
+                "2Q": {"0-1": {"fCZ": 0.96}},
+            }
+
+        device = Mock(spec=BraketDevice)
+        device._device = types.SimpleNamespace(
+            properties=types.SimpleNamespace(provider=RigettiProviderProperties())
+        )
+        device.num_qubits = 2
+
+        calibration = normalized_metadata(device)["calibration"]
+
+        assert calibration["avg_t1_s"] == pytest.approx(20e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(30e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.08)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.008)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.04)
+
+    def test_braket_device_metadata_includes_ionq_provider_calibration(self):
+        class IonqProviderProperties:
+            fidelity = {
+                "1Q": {"mean": 0.997},
+                "2Q": {"mean": 0.969},
+                "spam": {"mean": 0.996},
+            }
+
+        device = Mock(spec=BraketDevice)
+        device._device = types.SimpleNamespace(
+            properties=types.SimpleNamespace(provider=IonqProviderProperties())
+        )
+        device.num_qubits = 2
+
+        calibration = normalized_metadata(device)["calibration"]
+
+        assert calibration["avg_readout_error"] == pytest.approx(0.004)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.003)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.031)
 
     def test_unsupported_device_metadata(self):
         class Unsupported:

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -423,16 +423,38 @@ class TestNormalizedMetadata:
         standardized = types.SimpleNamespace(
             T1=types.SimpleNamespace(value=120, unit="us"),
             T2=types.SimpleNamespace(value=90, unit="us"),
-            readoutFidelity=[types.SimpleNamespace(fidelity=0.98)],
-            singleQubitFidelity=[types.SimpleNamespace(fidelity=0.997)],
-            twoQubitGateFidelity=[types.SimpleNamespace(fidelity=0.96)],
             oneQubitProperties={
                 "0": types.SimpleNamespace(
-                    oneQubitFidelity=[types.SimpleNamespace(fidelity=0.995)]
+                    oneQubitFidelity=[
+                        types.SimpleNamespace(
+                            fidelityType=types.SimpleNamespace(name="READOUT"),
+                            fidelity=0.98,
+                        ),
+                        types.SimpleNamespace(
+                            fidelityType=types.SimpleNamespace(name="RANDOMIZED_BENCHMARKING"),
+                            fidelity=0.995,
+                        ),
+                    ]
                 ),
                 "1": types.SimpleNamespace(
-                    oneQubitFidelity=[types.SimpleNamespace(fidelity=0.993)]
+                    oneQubitFidelity=[
+                        types.SimpleNamespace(
+                            fidelityType=types.SimpleNamespace(name="READOUT"),
+                            fidelity=0.96,
+                        ),
+                        types.SimpleNamespace(
+                            fidelityType=types.SimpleNamespace(
+                                name="SIMULTANEOUS_RANDOMIZED_BENCHMARKING"
+                            ),
+                            fidelity=0.993,
+                        ),
+                    ]
                 ),
+            },
+            twoQubitProperties={
+                "0-1": types.SimpleNamespace(
+                    twoQubitGateFidelity=[types.SimpleNamespace(gateName="cz", fidelity=0.96)]
+                )
             },
             updatedAt=datetime(2026, 1, 16, 15, 30, tzinfo=timezone.utc),
         )
@@ -445,8 +467,8 @@ class TestNormalizedMetadata:
 
         assert calibration["avg_t1_s"] == pytest.approx(120e-6)
         assert calibration["avg_t2_s"] == pytest.approx(90e-6)
-        assert calibration["avg_readout_error"] == pytest.approx(0.02)
-        assert calibration["avg_1q_gate_error"] == pytest.approx(0.005)
+        assert calibration["avg_readout_error"] == pytest.approx(0.03)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.006)
         assert calibration["avg_2q_gate_error"] == pytest.approx(0.04)
         assert calibration["last_update_date"] == "2026-01-16T15:30:00+00:00"
 


### PR DESCRIPTION
## Summary
- add normalized calibration metadata extraction for IBM/Qiskit backends
- add Amazon Braket calibration extraction from standardized device properties plus Rigetti and IonQ provider properties
- include calibration summaries in `platform.device_metadata.calibration` and document the exported JSON shape
- add exporter coverage to ensure nested calibration metadata is preserved in result payloads

Closes #668.

## Validation
- `Y:\db\goal_5_income\worktrees\metriq-gym-ibmq-fallback-521\.venv\Scripts\python.exe -m pytest -q tests\unit\qplatform tests\unit\exporters` (`78 passed`)
- `Y:\db\goal_5_income\worktrees\metriq-gym-ibmq-fallback-521\.venv\Scripts\python.exe -m ruff check`
- `Y:\db\goal_5_income\worktrees\metriq-gym-ibmq-fallback-521\.venv\Scripts\python.exe -m ruff format --check`
- `git diff --check`

I also ran `pytest -q tests\unit --ignore=tests\unit\test_run.py`; it reached `282 passed, 5 failed` with local Windows/environment failures unrelated to this patch: default `platformdirs` paths include the project author string with `<...>`, which is invalid on Windows, and replay tests require the uninitialized QED-C `_common` submodule import.

## AI assistance
AI assistance was used to help draft, review, and validate this change. I reviewed the implementation and test results before submitting.