### PR TITLE
Support local IBM noisy simulators without auth

### DIFF
--- a/docs/content/providers/local.md
+++ b/docs/content/providers/local.md
@@ -29,7 +29,7 @@ Common simulators include:
 Use any IBM device name (e.g., `ibm_sherbrooke`, `ibm_fez`) to run locally with that device's noise model.
 
 !!! note
-    Noise model simulators require valid IBM credentials to fetch the noise model, but execution is local.
+    Metriq-Gym first uses Qiskit's built-in fake IBM backend snapshots when one is available, so common noisy simulators do not require IBM credentials. If a device is not included in the local fake provider, valid IBM credentials are still required to fetch that backend.
 
 ## Usage
 
@@ -126,14 +126,15 @@ For benchmarks with multiple circuits, Aer parallelizes across available CPU cor
 
 When using `ibm_<device>` noise models:
 
-1. Metriq-Gym fetches the current noise model from IBM Quantum
-2. The model includes:
+1. Metriq-Gym uses a matching built-in fake backend snapshot when available
+2. If no local snapshot is available, Metriq-Gym fetches the current backend from IBM Quantum
+3. The model includes:
    - Single-qubit gate errors
    - Two-qubit gate errors
    - Readout errors
    - T1/T2 decoherence
-3. Circuits are transpiled to the device's basis gates
-4. Simulation runs locally with the noise model applied
+4. Circuits are transpiled to the device's basis gates
+5. Simulation runs locally with the noise model applied
 
 ### Noise Model Caching
 

--- a/metriq_gym/local/provider.py
+++ b/metriq_gym/local/provider.py
@@ -6,6 +6,22 @@ from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
 from metriq_gym.local.device import LocalAerDevice
 
 
+def _local_fake_backends() -> dict[str, object]:
+    return {backend.name: backend for backend in FakeProviderForBackendV2().backends()}
+
+
+def _local_fake_backend_alias(device_id: str, backends: dict[str, object]) -> str | None:
+    if device_id in backends:
+        return device_id
+
+    if device_id.startswith("ibm_"):
+        fake_device_id = f"fake_{device_id.removeprefix('ibm_')}"
+        if fake_device_id in backends:
+            return fake_device_id
+
+    return None
+
+
 class LocalProvider(QuantumProvider):
     def __init__(self) -> None:
         super().__init__()
@@ -14,6 +30,14 @@ class LocalProvider(QuantumProvider):
 
     def get_devices(self, **_) -> list[QuantumDevice]:
         devices = [self.device]
+
+        for device_id in sorted(_local_fake_backends()):
+            try:
+                device = self.get_device(device_id)
+                if device not in devices:
+                    devices.append(device)
+            except Exception:
+                pass
 
         # Try to get all available IBM fake backends.
         try:
@@ -45,10 +69,10 @@ class LocalProvider(QuantumProvider):
         try:
             # Try loading a local fake backend first, which doesn't require an
             # IBM Quantum account, otherwise load from the runtime service.
-
-            fake_local_backends = {b.name: b for b in FakeProviderForBackendV2().backends()}
-            if device_id in fake_local_backends:
-                backend = fake_local_backends[device_id]
+            local_backends = _local_fake_backends()
+            local_backend_id = _local_fake_backend_alias(device_id, local_backends)
+            if local_backend_id is not None:
+                backend = local_backends[local_backend_id]
             else:
                 backend = QiskitRuntimeService().backend(device_id)
             aer_backend = AerSimulator.from_backend(backend)

--- a/metriq_gym/local/provider.py
+++ b/metriq_gym/local/provider.py
@@ -11,6 +11,7 @@ def _local_fake_backends() -> dict[str, object]:
 
 
 def _local_fake_backend_alias(device_id: str, backends: dict[str, object]) -> str | None:
+    """Resolve `fake_*` and canonical `ibm_*` names to local fake backend IDs."""
     if device_id in backends:
         return device_id
 
@@ -27,11 +28,17 @@ class LocalProvider(QuantumProvider):
         super().__init__()
         self.device = LocalAerDevice(provider=self)
         self._devices: dict[str, LocalAerDevice] = {}
+        self._fake_local_backends: dict[str, object] | None = None
+
+    def _get_fake_local_backends(self) -> dict[str, object]:
+        if self._fake_local_backends is None:
+            self._fake_local_backends = _local_fake_backends()
+        return self._fake_local_backends
 
     def get_devices(self, **_) -> list[QuantumDevice]:
         devices = [self.device]
 
-        for device_id in sorted(_local_fake_backends()):
+        for device_id in sorted(self._get_fake_local_backends()):
             try:
                 device = self.get_device(device_id)
                 if device not in devices:
@@ -69,8 +76,12 @@ class LocalProvider(QuantumProvider):
         try:
             # Try loading a local fake backend first, which doesn't require an
             # IBM Quantum account, otherwise load from the runtime service.
-            local_backends = _local_fake_backends()
+            local_backends = self._get_fake_local_backends()
             local_backend_id = _local_fake_backend_alias(device_id, local_backends)
+            cache_key = local_backend_id or device_id
+            if cache_key in self._devices:
+                return self._devices[cache_key]
+
             if local_backend_id is not None:
                 backend = local_backends[local_backend_id]
             else:
@@ -80,5 +91,5 @@ class LocalProvider(QuantumProvider):
             raise ValueError("Unknown device identifier") from exc
 
         device = LocalAerDevice(provider=self, device_id=device_id, backend=aer_backend)
-        self._devices[device_id] = device
+        self._devices[cache_key] = device
         return device

--- a/tests/unit/local/test_provider.py
+++ b/tests/unit/local/test_provider.py
@@ -14,7 +14,7 @@ def test_get_devices_returns_list_with_device():
     """Test that get_devices returns at least the default aer_simulator when no IBM account is configured."""
     provider = LocalProvider()
     with (
-        patch("metriq_gym.local.provider._local_fake_backends", return_value={}),
+        patch.object(provider, "_get_fake_local_backends", return_value={}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
     ):
         # Simulate QiskitRuntimeService not configured
@@ -29,7 +29,7 @@ def test_get_devices_includes_ibm_backends_when_available():
     """Test that get_devices includes IBM backends when QiskitRuntimeService is configured."""
     provider = LocalProvider()
     with (
-        patch("metriq_gym.local.provider._local_fake_backends", return_value={}),
+        patch.object(provider, "_get_fake_local_backends", return_value={}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -65,7 +65,7 @@ def test_get_devices_includes_local_fake_backends_without_ibm_auth():
     aer_backend = MagicMock()
 
     with (
-        patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}),
+        patch.object(provider, "_get_fake_local_backends", return_value={"fake_torino": backend}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -74,7 +74,7 @@ def test_get_devices_includes_local_fake_backends_without_ibm_auth():
 
         devices = provider.get_devices()
 
-    assert [device.id for device in devices] == ["aer_simulator", "fake_torino"]
+    assert {device.id for device in devices} == {"aer_simulator", "fake_torino"}
     mock_service.assert_called_once()
     mock_aer.from_backend.assert_called_once_with(backend)
 
@@ -89,6 +89,20 @@ def test_local_fake_backend_alias_accepts_ibm_device_names():
     assert _local_fake_backend_alias("ibm_sherbrooke", backends) == "fake_sherbrooke"
     assert _local_fake_backend_alias("fake_torino", backends) == "fake_torino"
     assert _local_fake_backend_alias("ibm_unknown", backends) is None
+    assert _local_fake_backend_alias("IBM_Torino", backends) is None
+    assert _local_fake_backend_alias("ibm-torino", backends) is None
+    assert _local_fake_backend_alias("torino", backends) is None
+
+
+def test_fake_local_backends_are_cached_on_provider():
+    provider = LocalProvider()
+    backend = fake_backend("fake_torino")
+
+    with patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}) as fake_backends:
+        assert provider._get_fake_local_backends() == {"fake_torino": backend}
+        assert provider._get_fake_local_backends() == {"fake_torino": backend}
+
+    fake_backends.assert_called_once_with()
 
 
 def test_get_device_with_valid_id():
@@ -106,7 +120,7 @@ def test_get_device_with_invalid_id_raises():
 def test_get_device_with_noise_model():
     provider = LocalProvider()
     with (
-        patch("metriq_gym.local.provider._local_fake_backends", return_value={}),
+        patch.object(provider, "_get_fake_local_backends", return_value={}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -131,7 +145,7 @@ def test_get_device_uses_local_fake_backend_without_ibm_auth():
     aer_backend = MagicMock()
 
     with (
-        patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}),
+        patch.object(provider, "_get_fake_local_backends", return_value={"fake_torino": backend}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -151,7 +165,7 @@ def test_get_device_uses_local_fake_backend_for_ibm_name_without_ibm_auth():
     aer_backend = MagicMock()
 
     with (
-        patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}),
+        patch.object(provider, "_get_fake_local_backends", return_value={"fake_torino": backend}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -162,5 +176,28 @@ def test_get_device_uses_local_fake_backend_for_ibm_name_without_ibm_auth():
 
     assert isinstance(device, LocalAerDevice)
     assert device.id == "ibm_torino"
+    mock_service.assert_not_called()
+    mock_aer.from_backend.assert_called_once_with(backend)
+
+
+def test_get_device_reuses_cached_local_fake_backend_aliases():
+    provider = LocalProvider()
+    backend = fake_backend("fake_torino")
+    aer_backend = MagicMock()
+
+    with (
+        patch.object(provider, "_get_fake_local_backends", return_value={"fake_torino": backend}),
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = Exception("Not configured")
+        mock_aer.from_backend.return_value = aer_backend
+
+        ibm_device = provider.get_device("ibm_torino")
+        fake_device = provider.get_device("fake_torino")
+
+    assert ibm_device is fake_device
+    assert ibm_device.id == "ibm_torino"
+    assert list(provider._devices) == ["fake_torino"]
     mock_service.assert_not_called()
     mock_aer.from_backend.assert_called_once_with(backend)

--- a/tests/unit/local/test_provider.py
+++ b/tests/unit/local/test_provider.py
@@ -180,6 +180,46 @@ def test_get_device_uses_local_fake_backend_for_ibm_name_without_ibm_auth():
     mock_aer.from_backend.assert_called_once_with(backend)
 
 
+def test_get_device_resolves_real_qiskit_fake_backend_alias_without_ibm_auth(monkeypatch):
+    fake_backend_names = sorted(
+        backend.name
+        for backend in LocalProvider()._get_fake_local_backends().values()
+        if isinstance(backend.name, str) and backend.name.startswith("fake_")
+    )
+    if not fake_backend_names:
+        pytest.fail("FakeProviderForBackendV2 returned no fake_*-prefixed backends")
+
+    fake_backend_name = (
+        "fake_torino" if "fake_torino" in fake_backend_names else fake_backend_names[0]
+    )
+    ibm_device_id = fake_backend_name.replace("fake_", "ibm_", 1)
+
+    for key in (
+        "QISKIT_IBM_TOKEN",
+        "QISKIT_IBM_CHANNEL",
+        "QISKIT_IBM_INSTANCE",
+        "IBM_QUANTUM_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    class RuntimeServiceShouldNotBeNeeded:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "QiskitRuntimeService should not be required for local fake backend aliases"
+            )
+
+    monkeypatch.setattr(
+        "metriq_gym.local.provider.QiskitRuntimeService",
+        RuntimeServiceShouldNotBeNeeded,
+    )
+
+    device = LocalProvider().get_device(ibm_device_id)
+
+    assert isinstance(device, LocalAerDevice)
+    assert device.id == ibm_device_id
+    assert device.profile.simulator is True
+
+
 def test_get_device_reuses_cached_local_fake_backend_aliases():
     provider = LocalProvider()
     backend = fake_backend("fake_torino")

--- a/tests/unit/local/test_provider.py
+++ b/tests/unit/local/test_provider.py
@@ -1,13 +1,22 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from metriq_gym.local.provider import LocalProvider, LocalAerDevice
+from metriq_gym.local.provider import LocalProvider, LocalAerDevice, _local_fake_backend_alias
+
+
+def fake_backend(name: str):
+    backend = MagicMock()
+    backend.name = name
+    return backend
 
 
 def test_get_devices_returns_list_with_device():
     """Test that get_devices returns at least the default aer_simulator when no IBM account is configured."""
     provider = LocalProvider()
-    with patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service:
+    with (
+        patch("metriq_gym.local.provider._local_fake_backends", return_value={}),
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+    ):
         # Simulate QiskitRuntimeService not configured
         mock_service.side_effect = Exception("Not configured")
         devices = provider.get_devices()
@@ -20,6 +29,7 @@ def test_get_devices_includes_ibm_backends_when_available():
     """Test that get_devices includes IBM backends when QiskitRuntimeService is configured."""
     provider = LocalProvider()
     with (
+        patch("metriq_gym.local.provider._local_fake_backends", return_value={}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -48,6 +58,39 @@ def test_get_devices_includes_ibm_backends_when_available():
         assert "fake_jakarta" in provider._devices
 
 
+def test_get_devices_includes_local_fake_backends_without_ibm_auth():
+    """Test that local fake backends are listed without configuring IBM credentials."""
+    provider = LocalProvider()
+    backend = fake_backend("fake_torino")
+    aer_backend = MagicMock()
+
+    with (
+        patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}),
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = Exception("Not configured")
+        mock_aer.from_backend.return_value = aer_backend
+
+        devices = provider.get_devices()
+
+    assert [device.id for device in devices] == ["aer_simulator", "fake_torino"]
+    mock_service.assert_called_once()
+    mock_aer.from_backend.assert_called_once_with(backend)
+
+
+def test_local_fake_backend_alias_accepts_ibm_device_names():
+    backends = {
+        "fake_torino": fake_backend("fake_torino"),
+        "fake_sherbrooke": fake_backend("fake_sherbrooke"),
+    }
+
+    assert _local_fake_backend_alias("ibm_torino", backends) == "fake_torino"
+    assert _local_fake_backend_alias("ibm_sherbrooke", backends) == "fake_sherbrooke"
+    assert _local_fake_backend_alias("fake_torino", backends) == "fake_torino"
+    assert _local_fake_backend_alias("ibm_unknown", backends) is None
+
+
 def test_get_device_with_valid_id():
     provider = LocalProvider()
     device = provider.get_device("aer_simulator")
@@ -63,6 +106,7 @@ def test_get_device_with_invalid_id_raises():
 def test_get_device_with_noise_model():
     provider = LocalProvider()
     with (
+        patch("metriq_gym.local.provider._local_fake_backends", return_value={}),
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
@@ -79,3 +123,44 @@ def test_get_device_with_noise_model():
         mock_service.return_value.backend.assert_called_once_with(device_name)
         mock_aer.from_backend.assert_called_once_with(backend)
         assert provider.get_device(device_name) is device
+
+
+def test_get_device_uses_local_fake_backend_without_ibm_auth():
+    provider = LocalProvider()
+    backend = fake_backend("fake_torino")
+    aer_backend = MagicMock()
+
+    with (
+        patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}),
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = Exception("Not configured")
+        mock_aer.from_backend.return_value = aer_backend
+
+        device = provider.get_device("fake_torino")
+
+    assert isinstance(device, LocalAerDevice)
+    mock_service.assert_not_called()
+    mock_aer.from_backend.assert_called_once_with(backend)
+
+
+def test_get_device_uses_local_fake_backend_for_ibm_name_without_ibm_auth():
+    provider = LocalProvider()
+    backend = fake_backend("fake_torino")
+    aer_backend = MagicMock()
+
+    with (
+        patch("metriq_gym.local.provider._local_fake_backends", return_value={"fake_torino": backend}),
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = Exception("Not configured")
+        mock_aer.from_backend.return_value = aer_backend
+
+        device = provider.get_device("ibm_torino")
+
+    assert isinstance(device, LocalAerDevice)
+    assert device.id == "ibm_torino"
+    mock_service.assert_not_called()
+    mock_aer.from_backend.assert_called_once_with(backend)

--- a/tests/unit/local/test_provider.py
+++ b/tests/unit/local/test_provider.py
@@ -113,7 +113,12 @@ def test_get_device_with_valid_id():
 
 def test_get_device_with_invalid_id_raises():
     provider = LocalProvider()
-    with pytest.raises(ValueError, match="Unknown device identifier"):
+    with (
+        patch.object(provider, "_get_fake_local_backends", return_value={}),
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        pytest.raises(ValueError, match="Unknown device identifier"),
+    ):
+        mock_service.side_effect = Exception("Not configured")
         provider.get_device("invalid_id")
 
 


### PR DESCRIPTION
Closes #521.

## Summary

- Prefer Qiskit's built-in fake IBM backend snapshots for local noisy simulators
- Allow `ibm_*` device names such as `ibm_torino` to resolve to matching `fake_*` local backends when available
- Include local fake backends in the local provider device list and update the local provider docs
- Add regression coverage proving local noisy simulators do not require `QiskitRuntimeService` when a fake backend snapshot exists

## Tests

- `uv sync --group dev --frozen`
- `uv run --frozen pytest tests/unit/local/test_provider.py -q`
- `uv run --frozen ruff check metriq_gym/local/provider.py tests/unit/local/test_provider.py docs/content/providers/local.md`
- `uv run --frozen python - <<'PY'
from unittest.mock import patch
from metriq_gym.local.provider import LocalProvider
with patch('metriq_gym.local.provider.QiskitRuntimeService') as service:
    service.side_effect = AssertionError('IBM auth should not be touched')
    device = LocalProvider().get_device('ibm_torino')
print(device.id, device.profile.simulator, device.profile.num_qubits)
PY`

AI assistance disclosure: I used Codex as a coding assistant to inspect the issue path, prepare the patch, and run the checks above. I reviewed the final diff before submission.
