### PR TITLE
feat: add QAT Operator Loschmidt Echo benchmark

### DIFF
--- a/metriq_gym/benchmarks/qat_ole.py
+++ b/metriq_gym/benchmarks/qat_ole.py
@@ -1,0 +1,139 @@
+"""QAT Operator Loschmidt Echo (OLE) benchmark implementation.
+
+Summary:
+    Loads a pre-compiled circuit from the Quantum Advantage Tracker and estimates
+    the Operator Loschmidt Echo (OLE) by measuring ⟨Z_{q_0} ⊗ Z_{q_1} ⊗ Z_{q_2}⟩.
+
+Result interpretation:
+    Polling returns QATOLEResult.expectation_value as a BenchmarkScore:
+        - value: estimated Pauli-Z product expectation ⟨Z_{52} Z_{59} Z_{72}⟩.
+          Close to 1.0 indicates low decoherence; close to 0.0 indicates heavy noise.
+        - uncertainty: propagated binomial standard deviation from the parity fractions.
+    The ideal (noiseless) value for this echo protocol is 1.0.
+
+References:
+    - [Quantum Advantage Tracker OLE circuits](https://github.com/quantum-advantage-tracker/
+      quantum-advantage-tracker.github.io/tree/main/data/observable-estimations/
+      circuit-models/operator_loschmidt_echo)
+    - Algorithmiq model description:
+      https://algorithmiq.fi/wp-content/uploads/2025/11/model-information-flow-complex-material-document.pdf
+"""
+
+from __future__ import annotations
+
+import urllib.request
+from dataclasses import dataclass
+from math import sqrt
+from typing import TYPE_CHECKING
+
+from qiskit import QuantumCircuit, ClassicalRegister
+from qiskit import qasm3
+from metriq_gym.benchmarks.benchmark import (
+    Benchmark,
+    BenchmarkData,
+    BenchmarkResult,
+    BenchmarkScore,
+)
+from metriq_gym.helpers.task_helpers import flatten_counts
+from metriq_gym.resource_estimation import CircuitBatch
+
+if TYPE_CHECKING:
+    from qbraid import GateModelResultData, QuantumDevice, QuantumJob
+
+_BASE_URL = (
+    "https://raw.githubusercontent.com/quantum-advantage-tracker/"
+    "quantum-advantage-tracker.github.io/main/data/observable-estimations/"
+    "circuit-models/operator_loschmidt_echo/"
+)
+
+# All three circuits share the same observable: O = Z_52 Z_59 Z_72
+_OBSERVABLE_QUBITS = [52, 59, 72]
+
+_CIRCUIT_FILENAMES: dict[str, str] = {
+    "49Q_L3": "49Q_OLE_circuit_L_3_b_0.25_delta0.15.qasm",
+    "49Q_L6": "49Q_OLE_circuit_L_6_b_0.25_delta0.15.qasm",
+    "70Q_L6": "70Q_OLE_circuit_L_6_b_0.25_delta0.15.qasm",
+}
+
+
+def _fetch_qasm(circuit_name: str) -> str:
+    url = _BASE_URL + _CIRCUIT_FILENAMES[circuit_name]
+    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310
+        return resp.read().decode()
+
+
+def _build_ole_circuit(qasm_source: str, observable_qubits: list[int]) -> QuantumCircuit:
+    """Parse a QASM 3.0 source string and append measurements on the observable qubits."""
+    qc = qasm3.loads(qasm_source)
+    n_obs = len(observable_qubits)
+    cr = ClassicalRegister(n_obs, "c")
+    qc.add_register(cr)
+    for i, qubit_idx in enumerate(observable_qubits):
+        qc.measure(qubit_idx, cr[i])
+    return qc
+
+
+def _pauli_z_product_expectation(counts: dict[str, int]) -> tuple[float, float]:
+    """Compute ⟨Z_{q0} ... Z_{qk}⟩ from measurement-count bitstrings.
+
+    For a k-qubit Pauli-Z product, the bitstring parity determines the sign:
+      even parity (XOR = 0) contributes +1, odd parity (XOR = 1) contributes -1.
+
+    Returns:
+        (expectation, uncertainty) where expectation = P(even) - P(odd) and
+        uncertainty is the propagated binomial standard deviation.
+    """
+    total = sum(counts.values())
+    if total == 0:
+        return 0.0, 0.0
+
+    even_count = sum(
+        count for bitstring, count in counts.items() if sum(int(b) for b in bitstring) % 2 == 0
+    )
+    p_even = even_count / total
+    expectation = 2.0 * p_even - 1.0
+    uncertainty = 2.0 * sqrt(p_even * (1.0 - p_even) / total)
+    return expectation, uncertainty
+
+
+@dataclass
+class QATOLEData(BenchmarkData):
+    observable_qubits: list[int]
+    shots: int
+
+
+class QATOLEResult(BenchmarkResult):
+    expectation_value: BenchmarkScore
+
+    def compute_score(self) -> BenchmarkScore:
+        return self.expectation_value
+
+
+class QATOLE(Benchmark):
+    def _build_circuit(self) -> QuantumCircuit:
+        qasm_source = _fetch_qasm(self.params.circuit)
+        return _build_ole_circuit(qasm_source, _OBSERVABLE_QUBITS)
+
+    def dispatch_handler(self, device: "QuantumDevice") -> QATOLEData:
+        circuit = self._build_circuit()
+        return QATOLEData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            observable_qubits=_OBSERVABLE_QUBITS,
+            shots=self.params.shots,
+        )
+
+    def poll_handler(
+        self,
+        job_data: QATOLEData,
+        result_data: list["GateModelResultData"],
+        quantum_jobs: list["QuantumJob"],
+    ) -> QATOLEResult:
+        counts = flatten_counts(result_data)[0]
+        value, uncertainty = _pauli_z_product_expectation(counts)
+        return QATOLEResult(
+            expectation_value=BenchmarkScore(value=value, uncertainty=uncertainty)
+        )
+
+    def estimate_resources_handler(self, device: "QuantumDevice") -> list[CircuitBatch]:
+        circuit = self._build_circuit()
+        return [CircuitBatch(circuits=[circuit], shots=self.params.shots)]

--- a/metriq_gym/constants.py
+++ b/metriq_gym/constants.py
@@ -13,6 +13,7 @@ class JobType(StrEnum):
     HIDDEN_SHIFT = "Hidden Shift"
     QUANTUM_FOURIER_TRANSFORM = "Quantum Fourier Transform"
     LR_QAOA = "Linear Ramp QAOA"
+    QAT_OLE = "QAT OLE"
 
 
 SCHEMA_MAPPING = {
@@ -27,4 +28,5 @@ SCHEMA_MAPPING = {
     JobType.HIDDEN_SHIFT: "hidden_shift.schema.json",
     JobType.QUANTUM_FOURIER_TRANSFORM: "quantum_fourier_transform.schema.json",
     JobType.LR_QAOA: "lr_qaoa.schema.json",
+    JobType.QAT_OLE: "qat_ole.schema.json",
 }

--- a/metriq_gym/registry.py
+++ b/metriq_gym/registry.py
@@ -14,6 +14,7 @@ from metriq_gym.benchmarks.wit import WIT, WITData, WITResult
 from metriq_gym.benchmarks.qedc_benchmarks import QEDCBenchmark, QEDCData, QEDCResult
 from metriq_gym.benchmarks.lr_qaoa import LinearRampQAOA, LinearRampQAOAData, LinearRampQAOAResult
 from metriq_gym.benchmarks.eplg import EPLG, EPLGData, EPLGResult
+from metriq_gym.benchmarks.qat_ole import QATOLE, QATOLEData, QATOLEResult
 
 BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.BSEQ: BSEQ,
@@ -27,6 +28,7 @@ BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.HIDDEN_SHIFT: QEDCBenchmark,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCBenchmark,
     JobType.LR_QAOA: LinearRampQAOA,
+    JobType.QAT_OLE: QATOLE,
 }
 
 BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
@@ -41,6 +43,7 @@ BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
     JobType.HIDDEN_SHIFT: QEDCData,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCData,
     JobType.LR_QAOA: LinearRampQAOAData,
+    JobType.QAT_OLE: QATOLEData,
 }
 
 BENCHMARK_RESULT_CLASSES: dict[JobType, type[BenchmarkResult]] = {
@@ -55,6 +58,7 @@ BENCHMARK_RESULT_CLASSES: dict[JobType, type[BenchmarkResult]] = {
     JobType.HIDDEN_SHIFT: QEDCResult,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCResult,
     JobType.LR_QAOA: LinearRampQAOAResult,
+    JobType.QAT_OLE: QATOLEResult,
 }
 
 

--- a/metriq_gym/schemas/examples/qat_ole.example.json
+++ b/metriq_gym/schemas/examples/qat_ole.example.json
@@ -1,0 +1,5 @@
+{
+  "benchmark_name": "QAT OLE",
+  "circuit": "49Q_L3",
+  "shots": 1000
+}

--- a/metriq_gym/schemas/qat_ole.schema.json
+++ b/metriq_gym/schemas/qat_ole.schema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "metriq-gym/qat_ole.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "QAT OLE",
+  "description": "Quantum Advantage Tracker Operator Loschmidt Echo (OLE) benchmark. Loads a pre-compiled circuit from the QAT repository and estimates ⟨Z_52 Z_59 Z_72⟩, where a value close to 1.0 indicates low decoherence.",
+  "type": "object",
+  "properties": {
+    "benchmark_name": {
+      "type": "string",
+      "const": "QAT OLE",
+      "description": "Name of the benchmark. Must be 'QAT OLE' for this schema."
+    },
+    "circuit": {
+      "type": "string",
+      "description": "Which QAT OLE circuit to run. '49Q_L3' and '49Q_L6' use a 49-qubit Ising lattice with L=3 or L=6 Trotter steps. '70Q_L6' uses a 70-qubit lattice with L=6 steps. All circuits are transpiled to 156 physical qubits and require a large-scale quantum device.",
+      "enum": ["49Q_L3", "49Q_L6", "70Q_L6"],
+      "default": "49Q_L3",
+      "examples": ["49Q_L3", "49Q_L6", "70Q_L6"]
+    },
+    "shots": {
+      "type": "integer",
+      "description": "Number of measurement shots per circuit execution.",
+      "default": 1000,
+      "minimum": 1,
+      "examples": [1000, 4096]
+    }
+  },
+  "required": ["benchmark_name"]
+}

--- a/tests/e2e/test_all_benchmarks.py
+++ b/tests/e2e/test_all_benchmarks.py
@@ -18,10 +18,15 @@ def store_env(monkeypatch, tmp_path):
 
 def get_example_files():
     """Return all .json files in the examples directory."""
-    # Exclude LR QAOA native layout which won't work with the fully connected
-    # AER simulator device. Other LR QAOA examples should sufficiently exercise
-    # that benchmark.
-    excluded_files = {"lr_qaoa_native_layout.example.json"}
+    # Exclude benchmarks that cannot run on the local simulator:
+    # - lr_qaoa_native_layout: incompatible with the fully connected AER device.
+    # - qat_ole: circuits are pre-compiled to 156 physical qubits (from the
+    #   Quantum Advantage Tracker), which exceed any local simulator target.
+    #   This benchmark is intended for large-scale real hardware only.
+    excluded_files = {
+        "lr_qaoa_native_layout.example.json",
+        "qat_ole.example.json",
+    }
     res = [f for f in EXAMPLES_DIR.glob("*.json") if f.name not in excluded_files]
     return res
 

--- a/tests/unit/benchmarks/test_qat_ole.py
+++ b/tests/unit/benchmarks/test_qat_ole.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+
+import pytest
+
+from metriq_gym.benchmarks.benchmark import BenchmarkScore
+from metriq_gym.benchmarks.qat_ole import (
+    QATOLEResult,
+    _pauli_z_product_expectation,
+)
+from metriq_gym.constants import JobType
+from metriq_gym.exporters.base_exporter import BaseExporter
+from metriq_gym.job_manager import MetriqGymJob
+
+
+class _DummyExporter(BaseExporter):
+    def export(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _build_metriq_job() -> MetriqGymJob:
+    return MetriqGymJob(
+        id="test-job",
+        job_type=JobType.QAT_OLE,
+        params={"benchmark_name": "QAT OLE", "circuit": "49Q_L3", "shots": 1000},
+        data={"provider_job_ids": ["qid"], "observable_qubits": [52, 59, 72], "shots": 1000},
+        provider_name="provider",
+        device_name="device",
+        dispatch_time=datetime.now(),
+    )
+
+
+# --- Pauli-Z product expectation ---
+
+
+def test_pauli_z_product_expectation_all_even():
+    # All outcomes have even parity: expectation = 1.0
+    counts = {"000": 500, "011": 300, "101": 150, "110": 50}
+    value, uncertainty = _pauli_z_product_expectation(counts)
+    assert value == pytest.approx(1.0)
+    assert uncertainty == pytest.approx(0.0)
+
+
+def test_pauli_z_product_expectation_all_odd():
+    # All outcomes have odd parity: expectation = -1.0
+    counts = {"001": 400, "010": 300, "100": 200, "111": 100}
+    value, uncertainty = _pauli_z_product_expectation(counts)
+    assert value == pytest.approx(-1.0)
+    assert uncertainty == pytest.approx(0.0)
+
+
+def test_pauli_z_product_expectation_equal_split():
+    # Equal even/odd split: expectation = 0.0
+    counts = {"000": 500, "001": 500}
+    value, uncertainty = _pauli_z_product_expectation(counts)
+    assert value == pytest.approx(0.0)
+    assert uncertainty == pytest.approx(2.0 * (0.5 * 0.5 / 1000) ** 0.5)
+
+
+def test_pauli_z_product_expectation_empty_counts():
+    value, uncertainty = _pauli_z_product_expectation({})
+    assert value == pytest.approx(0.0)
+    assert uncertainty == pytest.approx(0.0)
+
+
+def test_pauli_z_product_expectation_single_qubit_one():
+    # Single-qubit case: outcome "1" is odd, "0" is even
+    counts = {"0": 700, "1": 300}
+    value, uncertainty = _pauli_z_product_expectation(counts)
+    # P(even) = 0.7, expectation = 2*0.7 - 1 = 0.4
+    assert value == pytest.approx(0.4)
+    assert uncertainty == pytest.approx(2.0 * (0.7 * 0.3 / 1000) ** 0.5)
+
+
+def test_pauli_z_product_expectation_ghz_two_qubit():
+    # GHZ state on 2 qubits: |00> + |11>; both outcomes have even parity
+    counts = {"00": 512, "11": 488}
+    value, uncertainty = _pauli_z_product_expectation(counts)
+    assert value == pytest.approx(1.0)
+    assert uncertainty == pytest.approx(0.0)
+
+
+# --- QATOLEResult model ---
+
+
+def test_qat_ole_result_score_properties():
+    result = QATOLEResult(expectation_value=BenchmarkScore(value=0.85, uncertainty=0.02))
+    assert result.score.value == pytest.approx(0.85)
+    assert result.score.uncertainty == pytest.approx(0.02)
+
+
+def test_qat_ole_result_values_and_uncertainties():
+    result = QATOLEResult(expectation_value=BenchmarkScore(value=0.72, uncertainty=0.03))
+    assert result.values == pytest.approx({"expectation_value": 0.72})
+    assert result.uncertainties == pytest.approx({"expectation_value": 0.03})
+
+
+def test_qat_ole_result_exporter_payload():
+    job = _build_metriq_job()
+    result = QATOLEResult(expectation_value=BenchmarkScore(value=0.91, uncertainty=0.01))
+    exporter = _DummyExporter(job, result)
+
+    payload = exporter.as_dict()
+    assert payload["results"]["expectation_value"]["value"] == pytest.approx(0.91)
+    assert payload["results"]["expectation_value"]["uncertainty"] == pytest.approx(0.01)
+    assert payload["results"]["score"]["value"] == pytest.approx(0.91)
+    assert payload["platform"] == {"provider": "provider", "device": "device"}
+
+
+def test_qat_ole_result_score_keys_match():
+    result = QATOLEResult(expectation_value=BenchmarkScore(value=0.5, uncertainty=0.05))
+    assert set(result.values.keys()) == {"expectation_value"}
+    assert set(result.uncertainties.keys()) == {"expectation_value"}


### PR DESCRIPTION
Closes #624

## What this adds

A new benchmark: **QAT Operator Loschmidt Echo (OLE)**, implementing the protocol from the [Quantum Advantage Tracker](https://github.com/quantum-advantage-tracker/quantum-advantage-tracker.github.io/tree/main/data/observable-estimations/circuit-models/operator_loschmidt_echo) (Algorithmiq, IBM, Flatiron Institute).

The OLE measures how well a quantum processor preserves operator dynamics under a Trotterized Ising Hamiltonian evolution perturbed by a small unitary V_δ:

$$f_\delta(O) = \frac{1}{2^n} \text{Tr}(U O U^\dagger V_\delta^\dagger U O U^\dagger V_\delta)$$

where O = Z_52 ⊗ Z_59 ⊗ Z_72 is the three-qubit Pauli-Z observable shared by all three circuit instances.

## Files changed

| File | Purpose |
|------|---------|
| `metriq_gym/benchmarks/qat_ole.py` | Benchmark implementation |
| `metriq_gym/schemas/qat_ole.schema.json` | JSON schema for config validation |
| `metriq_gym/schemas/examples/qat_ole.example.json` | Example config |
| `metriq_gym/constants.py` | Add `JobType.QAT_OLE = "QAT OLE"` |
| `metriq_gym/registry.py` | Register benchmark handler, data, result classes |
| `tests/unit/benchmarks/test_qat_ole.py` | 10 unit tests |

## How it works

1. **Dispatch**: Fetches one of three pre-compiled OpenQASM 3.0 circuits from the QAT GitHub repository (49Q_L3, 49Q_L6, or 70Q_L6). The circuits are transpiled to 156 physical qubits. Measurements on the observable qubits (q[52], q[59], q[72]) are appended before submission.

2. **Poll**: Computes the Pauli-Z product expectation value from the measurement bitstrings:
   - ⟨Z_52 Z_59 Z_72⟩ = P(even parity) − P(odd parity)
   - Ideal (noiseless) value: **1.0**
   - Noise drives the value toward **0.0**

3. **Score**: `expectation_value` with propagated binomial uncertainty (2σ from the parity fraction).

## Example config

```json
{
  "benchmark_name": "QAT OLE",
  "circuit": "49Q_L3",
  "shots": 1000
}
```

## Tests

10 unit tests covering the `_pauli_z_product_expectation` helper (all-even, all-odd, equal split, empty counts, single-qubit, GHZ) and the `QATOLEResult` model (score propagation, exporter payload, field key consistency). All pass.

## Notes

- The circuits require a large-scale quantum device (156 physical qubits); they cannot run on local simulators.
- The three circuit instances (`49Q_L3`, `49Q_L6`, `70Q_L6`) correspond to different Trotter depths L and lattice sizes.
- The observable O = Z_52 Z_59 Z_72 is identical for all three instances (confirmed from the QAT README).
