### PR TITLE
feat: add two-qubit gate counts (input + transpiled) to benchmark data

### DIFF
--- a/docs/content/development/adding-benchmarks.md
+++ b/docs/content/development/adding-benchmarks.md
@@ -47,8 +47,18 @@ class MyBenchmarkData(BenchmarkData):
     # Data needed between dispatch and poll
     expected_outputs: list[str]
     num_circuits: int
+```
 
+`BenchmarkData` also provides two inherited fields,
+`input_two_qubit_gate_counts` and `transpiled_two_qubit_gate_counts`
+(one entry per circuit, in dispatch order). Populate them in
+`dispatch_handler` using `two_qubit_gate_counts` from `metriq_gym.circuits`:
+pass the pre-transpilation circuits for the input counts and the circuits
+actually submitted for the transpiled counts. If the benchmark performs no
+transpilation, set both to the same list. These counts are surfaced in the
+exported results under `circuit_stats`.
 
+```python
 class MyBenchmark(Benchmark):
     """Benchmark implementation for My Benchmark."""
 

--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -3,7 +3,7 @@ from typing import Iterable, TYPE_CHECKING, Protocol
 from abc import ABC
 
 from pydantic import BaseModel, computed_field
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 if TYPE_CHECKING:
@@ -27,6 +27,13 @@ class BenchmarkData:
     """Stores intermediate data from pre-processing and dispatching"""
 
     provider_job_ids: list[str]
+
+    # Two-qubit gate counts per circuit, in dispatch order. Declared kw_only so
+    # subclasses can keep adding required positional fields without tripping the
+    # "non-default argument follows default" dataclass rule, and default to empty
+    # lists so job records persisted before these fields existed still load.
+    input_two_qubit_gate_counts: list[int] = field(default_factory=list, kw_only=True)
+    transpiled_two_qubit_gate_counts: list[int] = field(default_factory=list, kw_only=True)
 
     @classmethod
     def from_quantum_job(cls, quantum_job, **kwargs):

--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -42,6 +42,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
     BenchmarkScore,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.helpers.graph_helpers import (
     GraphColoring,
@@ -213,8 +214,18 @@ class BSEQ(Benchmark):
             for job in (quantum_job_set if isinstance(quantum_job_set, list) else [quantum_job_set])
         ]
 
+        # One count per circuit, flattened across the color sets in dispatch order.
+        # (Job IDs are per submitted set, so this list may be longer than
+        # provider_job_ids.) BSEQ submits circuits as built, so transpiled counts
+        # mirror input counts.
+        gate_counts = [
+            count for circ_set in circuit_sets for count in two_qubit_gate_counts(circ_set)
+        ]
+
         return BSEQData(
             provider_job_ids=provider_job_ids,
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
             shots=shots,
             num_qubits=device.num_qubits,
             topology_graph=topology_graph,

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -41,6 +41,8 @@ from metriq_gym.benchmarks.benchmark import (
 )
 import logging
 
+from metriq_gym.circuits import two_qubit_gate_counts
+
 from metriq_gym.qplatform.job import execution_time
 from metriq_gym.qplatform.device import (
     connectivity_graph,
@@ -390,13 +392,21 @@ class Clops(Benchmark):
         circuits = instantiate_circuits(
             template, parameters, self.params.num_circuits, seed=self.params.seed
         )
+        # CLOPS submits circuits as built, so the transpiled counts mirror the input counts.
+        gate_counts = two_qubit_gate_counts(circuits)
         if isinstance(device, QiskitBackend) and self.params.use_session:
             return ClopsData.from_quantum_job(
                 self._submit_ibm_with_options(
                     device, circuits, shots=self.params.shots, use_session=self.params.use_session
-                )
+                ),
+                input_two_qubit_gate_counts=gate_counts,
+                transpiled_two_qubit_gate_counts=gate_counts,
             )
-        return ClopsData.from_quantum_job(device.run(circuits, shots=self.params.shots))
+        return ClopsData.from_quantum_job(
+            device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
+        )
 
     def _dispatch_parameterized(self, device: QiskitBackend) -> ClopsData:
         """Send a single parameterized circuit with parameter arrays.
@@ -414,8 +424,11 @@ class Clops(Benchmark):
         ]
 
         pub = (template, param_values, self.params.shots)
+        gate_counts = two_qubit_gate_counts(template)
         return ClopsData.from_quantum_job(
-            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session)
+            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
         )
 
     def _dispatch_twirled(self, device: QiskitBackend) -> ClopsData:
@@ -433,6 +446,7 @@ class Clops(Benchmark):
             shots_per_randomization=self.params.shots,
             enable_gates=True,
         )
+        gate_counts = two_qubit_gate_counts(template)
         return ClopsData.from_quantum_job(
             self._submit_ibm_with_options(
                 device,
@@ -440,7 +454,9 @@ class Clops(Benchmark):
                 shots=self.params.shots * self.params.num_circuits,
                 twirling_options=twirling_opts,
                 use_session=self.params.use_session,
-            )
+            ),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
         )
 
     # ------------------------------------------------------------------

--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -38,6 +38,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkData,
     BenchmarkResult,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.qplatform.device import connectivity_graph, connectivity_graph_for_gate
 from metriq_gym.resource_estimation import CircuitBatch
 
@@ -313,12 +314,14 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def _build_circuits(
         self, device: "QuantumDevice"
-    ) -> tuple[list, list[int], list[list[tuple[int, int]]], str, list[str]]:
+    ) -> tuple[list, list, list[int], list[list[tuple[int, int]]], str, list[str]]:
         """Build LayerFidelity circuits.
 
         Returns:
-            Tuple of (circuits, qubit_chain, two_disjoint_layers,
-                      two_qubit_gate, one_qubit_basis_gates).
+            Tuple of (circuits, input_circuits, qubit_chain, two_disjoint_layers,
+                      two_qubit_gate, one_qubit_basis_gates). ``circuits`` are the
+            circuits actually submitted (transpiled when ``decompose_clifford_ops``
+            is set); ``input_circuits`` are always the pre-transpilation circuits.
         """
         num_qubits_in_chain = self.params.num_qubits_in_chain
         two_qubit_gate = self.params.two_qubit_gate
@@ -356,18 +359,31 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
         )
 
         lfexp.experiment_options.max_circuits = 2 * num_samples * len(lengths)
+        input_circuits = lfexp.circuits()
         if self.params.decompose_clifford_ops:
             circuits = lfexp._transpiled_circuits()
         else:
-            circuits = lfexp.circuits()
+            circuits = input_circuits
 
-        return circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates
+        return (
+            circuits,
+            input_circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+        )
 
     def dispatch_handler(self, device: "QuantumDevice") -> EPLGData:
         """Generate circuits, submit to device, return EPLGData."""
-        circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates = (
-            self._build_circuits(device)
-        )
+        (
+            circuits,
+            input_circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+        ) = self._build_circuits(device)
 
         shots = self.params.shots
         quantum_job = device.run(circuits, shots=shots)
@@ -377,6 +393,8 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
         return EPLGData.from_quantum_job(
             quantum_job,
+            input_two_qubit_gate_counts=two_qubit_gate_counts(input_circuits),
+            transpiled_two_qubit_gate_counts=two_qubit_gate_counts(circuits),
             num_qubits_in_chain=self.params.num_qubits_in_chain,
             qubit_chain=qubit_chain,
             two_disjoint_layers=serialized_layers,
@@ -478,5 +496,5 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def estimate_resources_handler(self, device: "QuantumDevice") -> list[CircuitBatch]:
         """Return circuit batches for resource estimation."""
-        circuits, _, _, _, _ = self._build_circuits(device)
+        circuits, _, _, _, _, _ = self._build_circuits(device)
         return [CircuitBatch(circuits=circuits, shots=self.params.shots)]

--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -43,6 +43,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
     BenchmarkScore,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.qplatform.device import connectivity_graph
 from metriq_gym.resource_estimation import CircuitBatch
@@ -450,6 +451,8 @@ class LinearRampQAOA(Benchmark):
 
         return LinearRampQAOAData.from_quantum_job(
             quantum_job=device.run(circuits_with_params, shots=self.params.shots),
+            input_two_qubit_gate_counts=two_qubit_gate_counts(circuits_with_params),
+            transpiled_two_qubit_gate_counts=two_qubit_gate_counts(circuits_with_params),
             num_qubits=self.params.num_qubits,
             graph_info=graph_info,
             optimal_sol=optimal_sol,

--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -38,6 +38,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
     BenchmarkScore,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.qplatform.device import connectivity_graph
 
@@ -558,8 +559,12 @@ class MirrorCircuits(Benchmark):
     def dispatch_handler(self, device: "QuantumDevice") -> MirrorCircuitsData:
         circuits, expected_bitstrings, actual_width = self._build_circuits(device)
 
+        # Mirror circuits submit as built, so transpiled counts mirror input counts.
+        gate_counts = two_qubit_gate_counts(circuits)
         return MirrorCircuitsData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
             num_layers=self.params.num_layers,
             two_qubit_gate_prob=self.params.two_qubit_gate_prob,
             two_qubit_gate_name=self.params.two_qubit_gate_name,

--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -30,6 +30,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
     BenchmarkScore,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.constants import JobType
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.resource_estimation import CircuitBatch
@@ -296,8 +297,12 @@ class QEDCBenchmark(Benchmark):
         # For more information on the parameters, view the schema for this benchmark.
         circuits, circuit_metrics, circuit_identifiers = self._build_circuits(device)
 
+        # QED-C circuits are submitted as built, so transpiled counts mirror input counts.
+        gate_counts = two_qubit_gate_counts(circuits)
         return QEDCData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
             circuit_metrics=circuit_metrics,
             circuit_identifiers=circuit_identifiers,
         )

--- a/metriq_gym/benchmarks/qml_kernel.py
+++ b/metriq_gym/benchmarks/qml_kernel.py
@@ -29,6 +29,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
     BenchmarkScore,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.resource_estimation import CircuitBatch
 
@@ -118,7 +119,13 @@ class QMLKernel(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> QMLKernelData:
         circuit = self._build_circuits(device)
-        return QMLKernelData.from_quantum_job(device.run(circuit, shots=self.params.shots))
+        # QML kernel submits the circuit as built, so transpiled counts mirror input counts.
+        gate_counts = two_qubit_gate_counts(circuit)
+        return QMLKernelData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
+        )
 
     def poll_handler(
         self,

--- a/metriq_gym/benchmarks/wit.py
+++ b/metriq_gym/benchmarks/wit.py
@@ -30,6 +30,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
     BenchmarkScore,
 )
+from metriq_gym.circuits import two_qubit_gate_counts
 from metriq_gym.helpers.statistics import (
     binary_expectation_stddev,
     binary_expectation_value,
@@ -260,7 +261,13 @@ class WIT(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> WITData:
         circuit = self._build_circuits(device)
-        return WITData.from_quantum_job(device.run(circuit, shots=self.params.shots))
+        # WIT submits the circuit as built, so transpiled counts mirror input counts.
+        gate_counts = two_qubit_gate_counts(circuit)
+        return WITData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            input_two_qubit_gate_counts=gate_counts,
+            transpiled_two_qubit_gate_counts=gate_counts,
+        )
 
     def poll_handler(
         self,

--- a/metriq_gym/circuits.py
+++ b/metriq_gym/circuits.py
@@ -2,11 +2,39 @@
 
 import math
 import random
+from collections.abc import Iterable
 from qiskit import QuantumCircuit
-from qiskit.circuit import Parameter, ParameterVector
+from qiskit.circuit import Gate, Parameter, ParameterVector
 import networkx as nx
 import numpy as np
 from typing import Literal, List, Tuple
+
+
+def two_qubit_gate_count(circuit: QuantumCircuit) -> int:
+    """Count the two-qubit gates in a circuit.
+
+    Only unitary gate operations acting on exactly two qubits are counted;
+    non-gate directives (``barrier``, ``measure``, ``reset``) and gates on
+    other widths are ignored, so a three-qubit gate is not miscounted as a
+    two-qubit gate.
+    """
+    return sum(
+        1
+        for instruction in circuit.data
+        if isinstance(instruction.operation, Gate) and instruction.operation.num_qubits == 2
+    )
+
+
+def two_qubit_gate_counts(circuits: QuantumCircuit | Iterable[QuantumCircuit]) -> list[int]:
+    """Return the per-circuit two-qubit gate counts, in order.
+
+    Accepts either a single circuit or an iterable of circuits and always
+    returns a flat ``list[int]`` with one entry per circuit.
+    """
+    if isinstance(circuits, QuantumCircuit):
+        circuits = [circuits]
+    return [two_qubit_gate_count(circuit) for circuit in circuits]
+
 
 GraphType = Literal[
     "1D", "NL", "FC"

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -39,6 +39,18 @@ class BaseExporter(ABC):
         if runtime_seconds is not None:
             record["runtime_seconds"] = runtime_seconds
 
+        # Surface the per-circuit two-qubit gate counts collected at dispatch time.
+        # These live on the BenchmarkData (job.data), which is otherwise not exported.
+        job_data = getattr(self.metriq_gym_job, "data", None)
+        if isinstance(job_data, dict):
+            circuit_stats = {
+                key: job_data[key]
+                for key in ("input_two_qubit_gate_counts", "transpiled_two_qubit_gate_counts")
+                if job_data.get(key)
+            }
+            if circuit_stats:
+                record["circuit_stats"] = circuit_stats
+
         # Richer suite metadata for downstream aggregation (e.g., metriq-data)
         suite_meta: dict[str, Any] = {}
         if self.metriq_gym_job.suite_id:

--- a/tests/unit/benchmarks/test_two_qubit_gate_counts.py
+++ b/tests/unit/benchmarks/test_two_qubit_gate_counts.py
@@ -1,0 +1,288 @@
+"""Tests for two-qubit gate counting in benchmark data (issue #715).
+
+Covers the counting helper, the new ``BenchmarkData`` fields (defaults,
+round-trip, backwards compatibility), a non-transpiling benchmark (CLOPS), a
+transpiling benchmark (EPLG), and the exporter surfacing the counts in JSON.
+"""
+
+import argparse
+from dataclasses import asdict
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import rustworkx as rx
+from qiskit import QuantumCircuit
+
+from metriq_gym.benchmarks.benchmark import BenchmarkData
+from metriq_gym.benchmarks.bseq import BSEQData
+from metriq_gym.benchmarks.clops import Clops, ClopsData
+from metriq_gym.circuits import two_qubit_gate_count, two_qubit_gate_counts
+from metriq_gym.constants import JobType
+from metriq_gym.exporters.dict_exporter import DictExporter
+from metriq_gym.job_manager import MetriqGymJob
+
+
+# ---------------------------------------------------------------------------
+# Counting helper
+# ---------------------------------------------------------------------------
+
+
+def test_count_only_two_qubit_gates():
+    qc = QuantumCircuit(3, 3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.cz(0, 2)
+    qc.barrier()
+    qc.measure(range(3), range(3))
+
+    assert two_qubit_gate_count(qc) == 3
+
+
+def test_three_qubit_gate_not_counted():
+    qc = QuantumCircuit(3)
+    qc.cx(0, 1)
+    qc.ccx(0, 1, 2)  # three-qubit, must not count
+
+    assert two_qubit_gate_count(qc) == 1
+
+
+def test_count_empty_circuit():
+    assert two_qubit_gate_count(QuantumCircuit(2)) == 0
+
+
+def test_parameterized_two_qubit_gate_counted():
+    from qiskit.circuit import Parameter
+
+    qc = QuantumCircuit(2)
+    qc.rzz(Parameter("t"), 0, 1)
+
+    assert two_qubit_gate_count(qc) == 1
+
+
+def test_counts_accepts_single_circuit():
+    qc = QuantumCircuit(2)
+    qc.cx(0, 1)
+
+    assert two_qubit_gate_counts(qc) == [1]
+
+
+def test_counts_preserves_order():
+    a = QuantumCircuit(2)
+    a.cx(0, 1)
+    b = QuantumCircuit(3)
+    b.cx(0, 1)
+    b.cx(1, 2)
+    c = QuantumCircuit(2)
+
+    assert two_qubit_gate_counts([a, b, c]) == [1, 2, 0]
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkData fields: defaults, round-trip, backwards compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_benchmarkdata_defaults_to_empty_lists():
+    data = BenchmarkData(provider_job_ids=["a"])
+
+    assert data.input_two_qubit_gate_counts == []
+    assert data.transpiled_two_qubit_gate_counts == []
+
+
+def test_subclass_with_required_fields_accepts_counts_kwonly():
+    # BSEQData adds required positional fields after the kw_only count fields;
+    # this must not raise "non-default argument follows default".
+    data = BSEQData(
+        provider_job_ids=["a"],
+        shots=10,
+        num_qubits=3,
+        input_two_qubit_gate_counts=[2, 2],
+        transpiled_two_qubit_gate_counts=[2, 2],
+    )
+
+    assert data.input_two_qubit_gate_counts == [2, 2]
+    assert data.transpiled_two_qubit_gate_counts == [2, 2]
+
+
+def test_asdict_roundtrip_preserves_counts():
+    data = ClopsData(
+        provider_job_ids=["a"],
+        input_two_qubit_gate_counts=[4, 4, 4],
+        transpiled_two_qubit_gate_counts=[4, 4, 4],
+    )
+    restored = ClopsData(**asdict(data))
+
+    assert restored == data
+
+
+def test_old_record_without_counts_still_loads():
+    # Records persisted before issue #715 lack the new keys; reconstruction must
+    # default them to empty lists rather than fail.
+    old_data = {"provider_job_ids": ["a"], "shots": 10, "num_qubits": 3}
+    data = BSEQData(**old_data)
+
+    assert data.input_two_qubit_gate_counts == []
+    assert data.transpiled_two_qubit_gate_counts == []
+
+
+# ---------------------------------------------------------------------------
+# Non-transpiling benchmark (CLOPS): transpiled mirrors input
+# ---------------------------------------------------------------------------
+
+
+def _linear_graph(n: int) -> rx.PyGraph:
+    g = rx.PyGraph()
+    g.add_nodes_from(range(n))
+    for i in range(n - 1):
+        g.add_edge(i, i + 1, None)
+    return g
+
+
+def _make_clops(**overrides) -> Clops:
+    defaults = dict(
+        benchmark_name="CLOPS",
+        num_qubits=4,
+        num_layers=2,
+        num_circuits=3,
+        shots=10,
+        seed=42,
+        two_qubit_gate="cz",
+        mode="instantiated",
+        use_session=False,
+    )
+    defaults.update(overrides)
+    params = MagicMock()
+    for k, v in defaults.items():
+        setattr(params, k, v)
+    return Clops(argparse.Namespace(), params)
+
+
+def test_clops_dispatch_populates_matching_counts():
+    clops = _make_clops()
+    device = MagicMock()
+    graph = _linear_graph(6)
+    mock_job = MagicMock()
+    mock_job.id = "job-123"
+    device.run.return_value = mock_job
+
+    with (
+        patch("metriq_gym.benchmarks.clops.connectivity_graph_for_gate", return_value=graph),
+        patch("metriq_gym.benchmarks.clops.connectivity_graph", return_value=graph),
+        patch("metriq_gym.benchmarks.clops.pruned_connectivity_graph", return_value=graph),
+    ):
+        result = clops.dispatch_handler(device)
+
+    submitted = device.run.call_args[0][0]
+    expected = two_qubit_gate_counts(submitted)
+
+    # One entry per submitted circuit, and transpiled mirrors input (no transpile step).
+    assert result.input_two_qubit_gate_counts == expected
+    assert result.transpiled_two_qubit_gate_counts == expected
+    assert len(result.input_two_qubit_gate_counts) == 3
+    assert all(count > 0 for count in result.input_two_qubit_gate_counts)
+
+
+# ---------------------------------------------------------------------------
+# Transpiling benchmark (EPLG): both counts populated from the right circuits
+# ---------------------------------------------------------------------------
+
+
+def _make_eplg(**overrides):
+    from metriq_gym.benchmarks.eplg import EPLG
+
+    defaults = dict(
+        benchmark_name="EPLG",
+        num_qubits_in_chain=4,
+        two_qubit_gate="cx",
+        one_qubit_basis_gates=["rz", "sx", "x"],
+        lengths=[1, 2],
+        num_samples=1,
+        shots=10,
+        seed=0,
+        decompose_clifford_ops=True,
+    )
+    defaults.update(overrides)
+    params = MagicMock()
+    for k, v in defaults.items():
+        setattr(params, k, v)
+    return EPLG(argparse.Namespace(), params)
+
+
+def test_eplg_dispatch_counts_input_and_transpiled_separately():
+    eplg = _make_eplg()
+    device = MagicMock()
+    mock_job = MagicMock()
+    mock_job.id = "eplg-job"
+    device.run.return_value = mock_job
+
+    input_circuits = [QuantumCircuit(2) for _ in range(2)]
+    for qc in input_circuits:
+        qc.cx(0, 1)  # one 2Q gate each before "transpilation"
+
+    transpiled_circuits = [QuantumCircuit(2) for _ in range(2)]
+    for qc in transpiled_circuits:
+        qc.cx(0, 1)
+        qc.cx(0, 1)
+        qc.cx(0, 1)  # three 2Q gates each after "transpilation"
+
+    build_return = (
+        transpiled_circuits,
+        input_circuits,
+        [0, 1, 2, 3],  # qubit_chain
+        [[(0, 1)], [(1, 2)]],  # two_disjoint_layers
+        "cx",
+        ["rz", "sx", "x"],
+    )
+    with patch.object(eplg, "_build_circuits", return_value=build_return):
+        result = eplg.dispatch_handler(device)
+
+    # device received the transpiled circuits
+    assert device.run.call_args[0][0] is transpiled_circuits
+    # input counts reflect the pre-transpile circuits, transpiled counts the submitted ones
+    assert result.input_two_qubit_gate_counts == [1, 1]
+    assert result.transpiled_two_qubit_gate_counts == [3, 3]
+
+
+# ---------------------------------------------------------------------------
+# Exporter surfaces the counts in the exported record
+# ---------------------------------------------------------------------------
+
+
+def _make_metriq_job(data: dict) -> MetriqGymJob:
+    return MetriqGymJob(
+        id="test-job",
+        job_type=JobType.CLOPS,
+        params={"benchmark_name": "CLOPS"},
+        data=data,
+        provider_name="provider",
+        device_name="device",
+        dispatch_time=datetime(2026, 6, 5, 12, 0, 0),
+    )
+
+
+def test_exporter_includes_circuit_stats():
+    job = _make_metriq_job(
+        {
+            "provider_job_ids": ["qid"],
+            "input_two_qubit_gate_counts": [4, 4, 4],
+            "transpiled_two_qubit_gate_counts": [6, 6, 6],
+        }
+    )
+    result = MagicMock()
+    result.model_dump.return_value = {"clops_score": 1.0}
+
+    record = DictExporter(job, result).export()
+
+    assert record["circuit_stats"]["input_two_qubit_gate_counts"] == [4, 4, 4]
+    assert record["circuit_stats"]["transpiled_two_qubit_gate_counts"] == [6, 6, 6]
+
+
+def test_exporter_omits_circuit_stats_when_absent():
+    job = _make_metriq_job({"provider_job_ids": ["qid"]})
+    result = MagicMock()
+    result.model_dump.return_value = {"clops_score": 1.0}
+
+    record = DictExporter(job, result).export()
+
+    assert "circuit_stats" not in record


### PR DESCRIPTION
# Description

Closes #715.

Records per-circuit two-qubit gate counts on `BenchmarkData` for both the input
circuits and the circuits actually submitted after any dispatch-path
transpilation, and surfaces them in the exported JSON. Two-qubit gate count is a
useful weighting/normalisation signal because transpilation can change it
significantly depending on the device coupling map and native gate set.

- `circuits.py`: `two_qubit_gate_count` / `two_qubit_gate_counts` helpers (count
  gate ops acting on exactly two qubits; barriers, measures and 3-qubit gates
  excluded).
- `benchmark.py`: `input_two_qubit_gate_counts` and
  `transpiled_two_qubit_gate_counts` on the base `BenchmarkData`, `kw_only` with
  empty-list defaults so subclasses keep their required positional fields and
  job records persisted before this change still load.
- All eight dispatch handlers populate both fields. Non-transpiling benchmarks
  (CLOPS, WIT, QML kernel, mirror circuits, LR-QAOA, QED-C) mirror input to
  transpiled; EPLG reports input from the pre-transpile circuits and transpiled
  from the submitted circuits.
- `base_exporter.py`: surfaces the counts as a `circuit_stats` block, read from
  the job data; omitted when absent so existing output is unchanged.
- Docs note in `adding-benchmarks.md`.
- Tests for the helper, the dataclass behaviour, CLOPS, EPLG and the exporter.

No new dependencies.

# Issue ticket number and link

Fixes #715 — https://github.com/unitaryfoundation/metriq-gym/issues/715

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

On Python 3.12 with `pip install -e . --group dev` (submodules initialised):

- `pytest tests/unit` — 316 passed (302 existing + 14 new in
  `tests/unit/benchmarks/test_two_qubit_gate_counts.py`).
- `ruff check metriq_gym/ tests/` — passed.
- `ruff format --check` — clean.
- `mypy metriq_gym/` — Success: no issues found in 50 source files.

New tests cover the counting helper (exact two-qubit gates only; barriers,
measures and 3-qubit gates excluded; order preserved), the new dataclass fields
(defaults, asdict round-trip, backwards compatibility with old records), a
non-transpiling benchmark (CLOPS, where transpiled mirrors input), a transpiling
benchmark (EPLG, where the two counts differ correctly), and the exporter.

# AI disclosure

This change was implemented with substantial help from Claude (Anthropic), which
drafted the counting helpers, the per-benchmark dispatch wiring, and the tests.
It was verified locally before submitting: the full unit suite (316 tests), ruff
and mypy all pass. The design choices are documented in the description above for
review: `kw_only` fields to avoid the dataclass non-default-ordering issue,
counting gates on exactly two qubits, and the exporter sourcing the counts from
the job data so `BenchmarkData` stays the single place they live.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
