### PR TITLE
Fix local IBM fake backends without auth

### DIFF
--- a/docs/content/providers/local.md
+++ b/docs/content/providers/local.md
@@ -26,10 +26,18 @@ Common simulators include:
 
 ### IBM Noise Model Simulators
 
-Use any IBM device name (e.g., `ibm_sherbrooke`, `ibm_fez`) to run locally with that device's noise model.
+Use an IBM device name (for example, `ibm_sherbrooke` or `ibm_fez`) to run
+locally with that device's noise model. If IBM credentials are configured,
+Metriq-Gym uses the live IBM backend data to build the simulator. If IBM
+credentials are not available, it falls back to the cached fake backend
+snapshots included with `qiskit-ibm-runtime`.
 
-!!! note
-    Noise model simulators require valid IBM credentials to fetch the noise model, but execution is local.
+Cached fake snapshots can be selected with either fake backend names or IBM
+aliases. For example, `fake_torino`, `ibm_torino`, `ibm-torino`,
+`IBM_Torino`, and `torino` all resolve to the Torino noise model locally.
+Device discovery lists fake snapshots without requiring IBM credentials, and
+authenticated discovery prefers live IBM backend names over duplicate fake
+twins.
 
 ## Usage
 
@@ -124,16 +132,19 @@ For benchmarks with multiple circuits, Aer parallelizes across available CPU cor
 
 ## Noise Model Details
 
-When using `ibm_<device>` noise models:
+When using `ibm_<device>` noise models with IBM credentials:
 
-1. Metriq-Gym fetches the current noise model from IBM Quantum
-2. The model includes:
+1. Metriq-Gym fetches the current backend data from IBM Quantum
+2. The generated simulator model includes:
    - Single-qubit gate errors
    - Two-qubit gate errors
    - Readout errors
    - T1/T2 decoherence
 3. Circuits are transpiled to the device's basis gates
 4. Simulation runs locally with the noise model applied
+
+Without IBM credentials, Metriq-Gym uses the corresponding cached
+`fake_<device>` snapshot when one is available.
 
 ### Noise Model Caching
 

--- a/metriq_gym/local/device.py
+++ b/metriq_gym/local/device.py
@@ -1,5 +1,7 @@
 import time
 import uuid
+from typing import Any, Protocol
+
 from qbraid import QPROGRAM, load_program
 from qbraid.runtime import QuantumDevice, DeviceStatus, TargetProfile
 from qbraid.programs import ExperimentType, ProgramSpec
@@ -8,8 +10,14 @@ from qiskit_aer import AerSimulator
 from .job import LocalAerJob
 
 
+class AerBackend(Protocol):
+    def configuration(self) -> Any: ...
+
+    def run(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
 def _make_profile(
-    *, device_id: str = "aer_simulator", backend: AerSimulator | None = None
+    *, device_id: str = "aer_simulator", backend: AerBackend | None = None
 ) -> TargetProfile:
     backend = backend or AerSimulator()
     cfg = backend.configuration()
@@ -27,7 +35,7 @@ def _make_profile(
 
 class LocalAerDevice(QuantumDevice):
     def __init__(
-        self, *, provider, device_id: str = "aer_simulator", backend: AerSimulator | None = None
+        self, *, provider, device_id: str = "aer_simulator", backend: AerBackend | None = None
     ) -> None:
         backend = backend or AerSimulator()
         super().__init__(_make_profile(device_id=device_id, backend=backend))

--- a/metriq_gym/local/provider.py
+++ b/metriq_gym/local/provider.py
@@ -1,9 +1,145 @@
+import logging
+from functools import cache
+from typing import Any
+
+from qbraid import QbraidError
 from qbraid.runtime import QuantumDevice, QuantumProvider
+from qiskit.exceptions import QiskitError
+from qiskit.providers import BackendV2
 from qiskit_aer import AerSimulator
+from qiskit_aer.backends.backendconfiguration import AerBackendConfiguration
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
 
 from metriq_gym.local.device import LocalAerDevice
+
+
+logger = logging.getLogger(__name__)
+
+_RUNTIME_LOOKUP_ERRORS = (QiskitError, ValueError, OSError)
+_DEVICE_PROFILE_ERRORS = (AttributeError, TypeError, ValueError, QiskitError)
+
+
+class UnknownLocalDeviceError(QbraidError, ValueError):
+    """Raised when a local device identifier cannot be resolved."""
+
+
+@cache
+def _aer_custom_instructions() -> tuple[str, ...]:
+    return tuple(
+        _as_string_list(getattr(AerSimulator().configuration(), "custom_instructions", []))
+    )
+
+
+def _as_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list | tuple | set | frozenset):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _backend_name(backend: BackendV2) -> str:
+    name = getattr(backend, "name", None)
+    if callable(name):
+        name = name()
+    if not isinstance(name, str):
+        raise TypeError("Backend does not expose a string name")
+    return name
+
+
+def _aer_profile_basis_gates(operation_names: list[str]) -> list[str]:
+    custom_instructions = list(_aer_custom_instructions())
+    # Mirrors qiskit-aer 0.17.x public from_backend configuration behavior:
+    # BackendV2 operation names feed AerBackendConfiguration, then Aer exposes
+    # physical basis gates followed by public custom instructions.
+    physical_gates = sorted(set(operation_names) - set(custom_instructions) - {"measure"})
+    return physical_gates + custom_instructions
+
+
+def _backend_operation_names(backend: BackendV2) -> list[str] | None:
+    operation_names = getattr(backend, "operation_names", None)
+    if isinstance(operation_names, list | tuple) and all(
+        isinstance(name, str) for name in operation_names
+    ):
+        return list(operation_names)
+    return None
+
+
+def _backend_coupling_map(backend: BackendV2) -> list[tuple[int, int]] | None:
+    coupling_map = getattr(backend, "coupling_map", None)
+    if coupling_map is None:
+        return None
+
+    get_edges = getattr(coupling_map, "get_edges", None)
+    if callable(get_edges):
+        return list(get_edges())
+
+    if isinstance(coupling_map, list):
+        return coupling_map
+
+    return None
+
+
+def _backend_max_circuits(backend: BackendV2) -> int | None:
+    max_circuits = getattr(backend, "max_circuits", None)
+    return max_circuits if isinstance(max_circuits, int) else None
+
+
+def _make_lazy_configuration(backend: BackendV2) -> Any:
+    operation_names = _backend_operation_names(backend)
+    backend_version = getattr(backend, "backend_version", None)
+    num_qubits = getattr(backend, "num_qubits", None)
+
+    if operation_names is None or not isinstance(num_qubits, int):
+        raise TypeError("BackendV2 is missing operation names or qubit count")
+    if not isinstance(backend_version, str):
+        backend_version = "0.0.0"
+
+    backend_name = _backend_name(backend)
+
+    description = getattr(backend, "description", None)
+    if not isinstance(description, str):
+        description = "created by AerSimulator.from_backend"
+
+    return AerBackendConfiguration(
+        backend_name=f"aer_simulator_from({backend_name})",
+        backend_version=backend_version,
+        n_qubits=num_qubits,
+        basis_gates=_aer_profile_basis_gates(operation_names),
+        gates=[],
+        max_shots=int(1e6),
+        coupling_map=_backend_coupling_map(backend),
+        max_experiments=_backend_max_circuits(backend),
+        description=description,
+    )
+
+
+class _LazyAerBackend:
+    def __init__(self, backend: BackendV2) -> None:
+        self._backend = backend
+        self._aer_backend: AerSimulator | None = None
+        self._configuration: Any | None = None
+
+    def _get_aer_backend(self) -> AerSimulator:
+        if self._aer_backend is None:
+            self._aer_backend = AerSimulator.from_backend(self._backend)
+            self._configuration = None
+        return self._aer_backend
+
+    def configuration(self) -> Any:
+        if self._aer_backend is not None:
+            return self._aer_backend.configuration()
+        if self._configuration is None:
+            try:
+                self._configuration = _make_lazy_configuration(self._backend)
+            except _DEVICE_PROFILE_ERRORS:
+                self._configuration = self._get_aer_backend().configuration()
+        return self._configuration
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        return self._get_aer_backend().run(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._get_aer_backend(), name)
 
 
 class LocalProvider(QuantumProvider):
@@ -11,50 +147,150 @@ class LocalProvider(QuantumProvider):
         super().__init__()
         self.device = LocalAerDevice(provider=self)
         self._devices: dict[str, LocalAerDevice] = {}
+        self._fake_local_backends: dict[str, BackendV2] | None = None
+
+    @staticmethod
+    def _normalize_device_id(device_id: str) -> str:
+        return device_id.strip().lower().replace("-", "_")
+
+    @classmethod
+    def _runtime_device_id(cls, device_id: str) -> str | None:
+        device_id = cls._normalize_device_id(device_id)
+        if device_id == "aer_simulator" or device_id.startswith("fake_"):
+            return None
+        if device_id.startswith("ibm_"):
+            return device_id
+        return f"ibm_{device_id}"
+
+    @classmethod
+    def _fake_device_id(cls, device_id: str) -> str:
+        device_id = cls._normalize_device_id(device_id)
+        if device_id.startswith("fake_"):
+            return device_id
+        if device_id.startswith("ibm_"):
+            return f"fake_{device_id.removeprefix('ibm_')}"
+        return f"fake_{device_id}"
+
+    @staticmethod
+    def _load_fake_local_backends() -> dict[str, BackendV2]:
+        return {
+            LocalProvider._normalize_device_id(_backend_name(backend)): backend
+            for backend in FakeProviderForBackendV2().backends()
+        }
+
+    def _get_fake_local_backends(self) -> dict[str, BackendV2]:
+        if self._fake_local_backends is None:
+            self._fake_local_backends = self._load_fake_local_backends()
+        return self._fake_local_backends
+
+    def _get_fake_backend(self, device_id: str) -> tuple[str, BackendV2] | None:
+        fake_device_id = self._fake_device_id(device_id)
+        backend = self._get_fake_local_backends().get(fake_device_id)
+        if backend is None:
+            return None
+        return fake_device_id, backend
+
+    def _make_device(
+        self,
+        device_id: str,
+        backend: BackendV2,
+        *,
+        cache_key: str | None = None,
+        lazy: bool = False,
+    ) -> LocalAerDevice:
+        normalized_device_id = self._normalize_device_id(device_id)
+        normalized_cache_key = self._normalize_device_id(cache_key or device_id)
+        if normalized_cache_key in self._devices:
+            return self._devices[normalized_cache_key]
+
+        aer_backend = _LazyAerBackend(backend) if lazy else AerSimulator.from_backend(backend)
+        device = LocalAerDevice(
+            provider=self, device_id=normalized_device_id, backend=aer_backend
+        )
+        self._devices[normalized_cache_key] = device
+        return device
+
+    def _append_device(
+        self, devices: list[QuantumDevice], device_id: str, backend: BackendV2
+    ) -> None:
+        device = self._make_device(device_id, backend, lazy=True)
+        if device not in devices:
+            devices.append(device)
 
     def get_devices(self, **_) -> list[QuantumDevice]:
         devices = [self.device]
+        runtime_fake_twins: set[str] = set()
 
-        # Try to get all available IBM fake backends.
+        service = None
         try:
             service = QiskitRuntimeService()
-            backends = service.backends()
-            # Add available backends to the list
-            for backend in backends:
-                device_id = backend.name
+        except _RUNTIME_LOOKUP_ERRORS as exc:
+            logger.debug("IBM Runtime service is unavailable for local listing.", exc_info=exc)
+
+        if service is not None:
+            try:
+                runtime_backends = service.backends()
+            except _RUNTIME_LOOKUP_ERRORS as exc:
+                logger.debug("Could not list IBM Runtime backends.", exc_info=exc)
+                runtime_backends = []
+
+            for backend in runtime_backends:
                 try:
-                    # Get or create the device (this will cache it in self._devices)
-                    device = self.get_device(device_id)
-                    if device not in devices:
-                        devices.append(device)
-                except Exception:
-                    # Skip backends that can't be loaded
-                    pass
-        except Exception:
-            # QiskitRuntimeService not configured or other error - just continue
-            pass
+                    device_id = self._normalize_device_id(_backend_name(backend))
+                    self._append_device(devices, device_id, backend)
+                    runtime_fake_twins.add(self._fake_device_id(device_id))
+                except _DEVICE_PROFILE_ERRORS as exc:
+                    logger.debug("Could not add IBM Runtime backend.", exc_info=exc)
+
+        for device_id, backend in self._get_fake_local_backends().items():
+            if device_id in runtime_fake_twins:
+                continue
+            try:
+                self._append_device(devices, device_id, backend)
+            except _DEVICE_PROFILE_ERRORS as exc:
+                logger.debug("Could not add local fake backend %s.", device_id, exc_info=exc)
 
         return devices
 
     def get_device(self, device_id: str) -> QuantumDevice:
-        if device_id in self._devices:
-            return self._devices[device_id]
+        device_id = self._normalize_device_id(device_id)
 
         if device_id == "aer_simulator":
             return self.device
+
+        runtime_device_id = self._runtime_device_id(device_id)
+        if runtime_device_id is not None and runtime_device_id in self._devices:
+            return self._devices[runtime_device_id]
+
+        if device_id in self._devices:
+            return self._devices[device_id]
+
+        fake_cache_key = self._fake_device_id(device_id)
+        if fake_cache_key in self._devices:
+            return self._devices[fake_cache_key]
+
+        if runtime_device_id is not None:
+            try:
+                backend = QiskitRuntimeService().backend(runtime_device_id)
+                return self._make_device(runtime_device_id, backend)
+            except _RUNTIME_LOOKUP_ERRORS as exc:
+                logger.debug(
+                    "Falling back from IBM Runtime backend %s to local fake backend.",
+                    runtime_device_id,
+                    exc_info=exc,
+                )
+
+        fake_backend_info = self._get_fake_backend(device_id)
+        if fake_backend_info is None:
+            raise UnknownLocalDeviceError("Unknown device identifier")
+
+        resolved_fake_device_id, fake_backend = fake_backend_info
+        display_device_id = runtime_device_id or resolved_fake_device_id
         try:
-            # Try loading a local fake backend first, which doesn't require an
-            # IBM Quantum account, otherwise load from the runtime service.
-
-            fake_local_backends = {b.name: b for b in FakeProviderForBackendV2().backends()}
-            if device_id in fake_local_backends:
-                backend = fake_local_backends[device_id]
-            else:
-                backend = QiskitRuntimeService().backend(device_id)
-            aer_backend = AerSimulator.from_backend(backend)
-        except Exception as exc:
-            raise ValueError("Unknown device identifier") from exc
-
-        device = LocalAerDevice(provider=self, device_id=device_id, backend=aer_backend)
-        self._devices[device_id] = device
-        return device
+            return self._make_device(
+                display_device_id,
+                fake_backend,
+                cache_key=resolved_fake_device_id,
+            )
+        except _DEVICE_PROFILE_ERRORS as exc:
+            raise UnknownLocalDeviceError("Unknown device identifier") from exc

--- a/tests/unit/local/test_provider.py
+++ b/tests/unit/local/test_provider.py
@@ -1,51 +1,285 @@
-import pytest
+import logging
 from unittest.mock import MagicMock, patch
 
-from metriq_gym.local.provider import LocalProvider, LocalAerDevice
+import pytest
+from qbraid import QbraidError
+from qiskit_aer import AerSimulator
+
+from metriq_gym.local.provider import (
+    LocalProvider,
+    LocalAerDevice,
+    _aer_custom_instructions,
+    UnknownLocalDeviceError,
+)
+from metriq_gym.qplatform.device import connectivity_graph, version
+
+
+class _MockCouplingMap:
+    def get_edges(self) -> list[tuple[int, int]]:
+        return [(0, 1), (1, 2)]
+
+
+class _MockBackendV2WithoutConfiguration:
+    name = "ibm_torino"
+    num_qubits = 3
+    operation_names = ["ecr", "id", "rz", "sx", "x"]
+    coupling_map = _MockCouplingMap()
+    max_circuits = 100
+    description = None
+
+    def __init__(self, backend_version: str | None = "1.2.3") -> None:
+        self.backend_version = backend_version
+
+    def configuration(self):
+        raise AssertionError("BackendV2 listing should not require configuration()")
+
+
+@pytest.fixture(autouse=True)
+def clear_aer_helper_caches():
+    _aer_custom_instructions.cache_clear()
+    yield
+    _aer_custom_instructions.cache_clear()
+
+
+def _mock_backend(name: str, num_qubits: int = 5) -> MagicMock:
+    backend = MagicMock()
+    backend.name = name
+    backend.backend_version = "1.0.0"
+    backend.num_qubits = num_qubits
+    backend.operation_names = ["id", "x", "sx", "rz", "cx", "measure"]
+    backend.coupling_map = None
+    backend.max_circuits = None
+    backend.description = None
+    config = MagicMock()
+    config.num_qubits = num_qubits
+    config.n_qubits = num_qubits
+    config.basis_gates = ["id", "x", "sx", "rz", "cx"]
+    config.backend_version = "1.0.0"
+    config.coupling_map = None
+    backend.configuration.return_value = config
+    return backend
+
+
+def _mock_aer_backend(num_qubits: int = 5) -> MagicMock:
+    backend = MagicMock()
+    config = MagicMock()
+    config.num_qubits = num_qubits
+    config.n_qubits = num_qubits
+    config.basis_gates = ["id", "x", "sx", "rz", "cx"]
+    config.backend_version = "1.0.0"
+    config.coupling_map = None
+    backend.configuration.return_value = config
+    return backend
 
 
 def test_get_devices_returns_list_with_device():
-    """Test that get_devices returns at least the default aer_simulator when no IBM account is configured."""
-    provider = LocalProvider()
-    with patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service:
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+    ):
+        provider = LocalProvider()
         # Simulate QiskitRuntimeService not configured
-        mock_service.side_effect = Exception("Not configured")
+        mock_service.side_effect = ValueError("Not configured")
+        mock_fake_provider.return_value.backends.return_value = []
         devices = provider.get_devices()
         assert isinstance(devices, list)
         assert len(devices) == 1
         assert devices[0] is provider.device
 
 
-def test_get_devices_includes_ibm_backends_when_available():
-    """Test that get_devices includes IBM backends when QiskitRuntimeService is configured."""
-    provider = LocalProvider()
+def test_get_devices_includes_fake_backends_without_ibm_account():
+    """Test that local fake backends are listed without IBM Runtime authentication."""
+    mock_backend = _mock_backend("fake_torino")
+
     with (
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = ValueError("Not configured")
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_aer.from_backend.return_value = MagicMock()
+
+        provider = LocalProvider()
+        devices = provider.get_devices()
+
+        assert len(devices) == 2
+        assert devices[0] is provider.device
+        assert "fake_torino" in provider._devices
+        assert provider._devices["fake_torino"] in devices
+        mock_service.assert_called_once()
+        mock_aer.from_backend.assert_not_called()
+
+
+def test_get_devices_includes_ibm_backends_when_available():
+    """Test that get_devices includes IBM backends when QiskitRuntimeService is configured."""
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
         # Create mock backends
-        mock_backend1 = MagicMock()
-        mock_backend1.name = "fake_manila"
-        mock_backend2 = MagicMock()
-        mock_backend2.name = "fake_jakarta"
+        mock_backend1 = _mock_backend("ibm_manila")
+        mock_backend2 = _mock_backend("ibm_jakarta")
 
+        mock_fake_provider.return_value.backends.return_value = []
         mock_service.return_value.backends.return_value = [mock_backend1, mock_backend2]
-        mock_service.return_value.backend.side_effect = lambda name: (
-            mock_backend1 if name == "fake_manila" else mock_backend2
-        )
 
-        # Mock AerSimulator.from_backend to return a valid backend
-        mock_aer.from_backend.return_value = MagicMock()
-
+        provider = LocalProvider()
         devices = provider.get_devices()
 
         assert isinstance(devices, list)
-        # Should have aer_simulator + 2 fake backends
+        # Should have aer_simulator + 2 runtime backends
         assert len(devices) == 3
         assert devices[0] is provider.device
         # Verify the other devices are in the cache
-        assert "fake_manila" in provider._devices
-        assert "fake_jakarta" in provider._devices
+        assert "ibm_manila" in provider._devices
+        assert "ibm_jakarta" in provider._devices
+        mock_service.return_value.backend.assert_not_called()
+        mock_aer.from_backend.assert_not_called()
+
+
+def test_get_devices_deduplicates_runtime_backend_with_fake_twin():
+    """Authenticated listings prefer the live IBM backend over its fake twin."""
+    fake_backend = _mock_backend("fake_torino", num_qubits=133)
+    runtime_backend = _mock_backend("ibm_torino", num_qubits=133)
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [fake_backend]
+        mock_service.return_value.backends.return_value = [runtime_backend]
+
+        provider = LocalProvider()
+        devices = provider.get_devices()
+
+        assert len(devices) == 2
+        assert "ibm_torino" in provider._devices
+        assert "fake_torino" not in provider._devices
+        assert provider._devices["ibm_torino"] in devices
+        mock_aer.from_backend.assert_not_called()
+
+
+def test_get_devices_handles_runtime_backend_without_configuration():
+    """BackendV2 runtime listings use attributes instead of deprecated configuration()."""
+    fake_backend = _mock_backend("fake_torino", num_qubits=133)
+    runtime_backend = _MockBackendV2WithoutConfiguration()
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch(
+            "metriq_gym.local.provider._aer_custom_instructions",
+            return_value=["delay", "reset"],
+        ),
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [fake_backend]
+        mock_service.return_value.backends.return_value = [runtime_backend]
+
+        provider = LocalProvider()
+        devices = provider.get_devices()
+        device = provider._devices["ibm_torino"]
+
+        assert len(devices) == 2
+        assert "fake_torino" not in provider._devices
+        assert device in devices
+        assert device.profile.basis_gates == {
+            "ecr",
+            "id",
+            "rz",
+            "sx",
+            "x",
+            "delay",
+            "reset",
+        }
+        assert version(device) == "1.2.3"
+        assert sorted(connectivity_graph(device).edge_list()) == [(0, 1), (1, 2)]
+        mock_aer.from_backend.assert_not_called()
+
+
+def test_get_devices_handles_runtime_backend_with_none_backend_version():
+    """BackendV2 listings with default None versions still avoid configuration()."""
+    fake_backend = _mock_backend("fake_torino", num_qubits=133)
+    runtime_backend = _MockBackendV2WithoutConfiguration(backend_version=None)
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch(
+            "metriq_gym.local.provider._aer_custom_instructions",
+            return_value=["delay", "reset"],
+        ),
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [fake_backend]
+        mock_service.return_value.backends.return_value = [runtime_backend]
+
+        provider = LocalProvider()
+        devices = provider.get_devices()
+        device = provider._devices["ibm_torino"]
+
+        assert len(devices) == 2
+        assert "fake_torino" not in provider._devices
+        assert device in devices
+        assert device.profile.basis_gates == {
+            "ecr",
+            "id",
+            "rz",
+            "sx",
+            "x",
+            "delay",
+            "reset",
+        }
+        assert version(device) == "0.0.0"
+        assert sorted(connectivity_graph(device).edge_list()) == [(0, 1), (1, 2)]
+        mock_aer.from_backend.assert_not_called()
+
+
+def test_get_devices_logs_runtime_service_failures(caplog):
+    caplog.set_level(logging.DEBUG, logger="metriq_gym.local.provider")
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+    ):
+        mock_service.side_effect = ValueError("Not configured")
+        mock_fake_provider.return_value.backends.return_value = []
+
+        provider = LocalProvider()
+        provider.get_devices()
+
+    assert "IBM Runtime service is unavailable for local listing." in caplog.text
+
+
+def test_fake_backend_registry_is_loaded_lazily():
+    with patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider:
+        provider = LocalProvider()
+        provider.get_device("aer_simulator")
+
+    mock_fake_provider.assert_not_called()
+
+
+def test_fake_local_backends_are_cached_on_provider():
+    mock_backend = _mock_backend("fake_torino")
+
+    with patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider:
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+
+        provider = LocalProvider()
+        assert provider._get_fake_local_backends() == {"fake_torino": mock_backend}
+        assert provider._get_fake_local_backends() == {"fake_torino": mock_backend}
+
+    mock_fake_provider.assert_called_once()
+
+
+def test_unknown_local_device_error_preserves_old_value_error_contract():
+    error = UnknownLocalDeviceError("Unknown device identifier")
+
+    assert isinstance(error, QbraidError)
+    assert isinstance(error, ValueError)
 
 
 def test_get_device_with_valid_id():
@@ -55,27 +289,290 @@ def test_get_device_with_valid_id():
 
 
 def test_get_device_with_invalid_id_raises():
-    provider = LocalProvider()
-    with pytest.raises(ValueError, match="Unknown device identifier"):
-        provider.get_device("invalid_id")
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+    ):
+        provider = LocalProvider()
+        mock_fake_provider.return_value.backends.return_value = []
+        mock_service.return_value.backend.side_effect = ValueError("Unknown backend")
+
+        with pytest.raises(UnknownLocalDeviceError, match="Unknown device identifier"):
+            provider.get_device("invalid_id")
+
+        mock_service.return_value.backend.assert_called_once_with("ibm_invalid_id")
 
 
 def test_get_device_with_noise_model():
-    provider = LocalProvider()
     with (
         patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
         patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
     ):
-        backend = MagicMock()
-        backend.name = "fake_backend"
+        backend = _mock_backend("ibm_backend")
+        mock_fake_provider.return_value.backends.return_value = []
         mock_service.return_value.backend.return_value = backend
-        aer_backend = MagicMock()
+        aer_backend = _mock_aer_backend()
         mock_aer.from_backend.return_value = aer_backend
 
-        device_name = "fake_backend"
+        provider = LocalProvider()
+        device_name = "ibm_backend"
         device = provider.get_device(device_name)
 
         assert isinstance(device, LocalAerDevice)
         mock_service.return_value.backend.assert_called_once_with(device_name)
         mock_aer.from_backend.assert_called_once_with(backend)
         assert provider.get_device(device_name) is device
+
+
+def test_get_device_uses_runtime_backend_before_fake_alias_when_ibm_account_available():
+    fake_backend = _mock_backend("fake_torino", num_qubits=133)
+    runtime_backend = _mock_backend("ibm_torino", num_qubits=133)
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [fake_backend]
+        mock_service.return_value.backend.return_value = runtime_backend
+        aer_backend = _mock_aer_backend(num_qubits=133)
+        mock_aer.from_backend.return_value = aer_backend
+
+        provider = LocalProvider()
+        device = provider.get_device("ibm_torino")
+
+        assert isinstance(device, LocalAerDevice)
+        mock_service.return_value.backend.assert_called_once_with("ibm_torino")
+        mock_aer.from_backend.assert_called_once_with(runtime_backend)
+        assert provider.get_device("ibm_torino") is device
+
+
+def test_get_device_uses_fake_backend_alias_without_ibm_account():
+    mock_backend = _mock_backend("fake_torino", num_qubits=133)
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_service.return_value.backend.side_effect = ValueError("Not configured")
+        aer_backend = _mock_aer_backend(num_qubits=133)
+        mock_aer.from_backend.return_value = aer_backend
+
+        provider = LocalProvider()
+        device = provider.get_device("ibm_torino")
+        cached_device = provider.get_device("ibm_torino")
+
+        assert isinstance(device, LocalAerDevice)
+        mock_service.return_value.backend.assert_called_once_with("ibm_torino")
+        mock_aer.from_backend.assert_called_once_with(mock_backend)
+        assert cached_device is device
+        assert list(provider._devices) == ["fake_torino"]
+
+
+def test_get_device_reuses_cached_local_fake_backend_aliases():
+    mock_backend = _mock_backend("fake_torino", num_qubits=133)
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_service.return_value.backend.side_effect = ValueError("Not configured")
+        mock_aer.from_backend.return_value = _mock_aer_backend(num_qubits=133)
+
+        provider = LocalProvider()
+        ibm_device = provider.get_device("ibm_torino")
+        fake_device = provider.get_device("fake_torino")
+        bare_device = provider.get_device("torino")
+
+    assert ibm_device is fake_device is bare_device
+    assert ibm_device.id == "ibm_torino"
+    assert list(provider._devices) == ["fake_torino"]
+    mock_service.return_value.backend.assert_called_once_with("ibm_torino")
+    mock_aer.from_backend.assert_called_once_with(mock_backend)
+
+
+@pytest.mark.parametrize(
+    ("device_id", "expected_device_id", "expects_runtime_lookup"),
+    [
+        ("IBM-Torino", "ibm_torino", True),
+        ("torino", "ibm_torino", True),
+        ("fake-torino", "fake_torino", False),
+    ],
+)
+def test_get_device_normalizes_fake_backend_aliases(
+    device_id: str, expected_device_id: str, expects_runtime_lookup: bool
+):
+    mock_backend = _mock_backend("fake_torino", num_qubits=133)
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_service.return_value.backend.side_effect = ValueError("Not configured")
+        mock_aer.from_backend.return_value = _mock_aer_backend(num_qubits=133)
+
+        provider = LocalProvider()
+        device = provider.get_device(device_id)
+
+        assert isinstance(device, LocalAerDevice)
+        assert device.id == expected_device_id
+        mock_aer.from_backend.assert_called_once_with(mock_backend)
+        if expects_runtime_lookup:
+            mock_service.return_value.backend.assert_called_once_with("ibm_torino")
+        else:
+            mock_service.assert_not_called()
+
+
+def test_get_device_missing_fake_alias_attempts_runtime_then_raises():
+    mock_backend = _mock_backend("fake_torino")
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_service.return_value.backend.side_effect = ValueError("Unknown backend")
+
+        provider = LocalProvider()
+        with pytest.raises(UnknownLocalDeviceError, match="Unknown device identifier"):
+            provider.get_device("ibm_doesnotexist")
+
+        mock_service.return_value.backend.assert_called_once_with("ibm_doesnotexist")
+        mock_aer.from_backend.assert_not_called()
+
+
+def test_get_devices_listed_fake_backend_constructs_aer_on_submit():
+    mock_backend = _mock_backend("fake_torino", num_qubits=133)
+    aer_backend = _mock_aer_backend(num_qubits=133)
+    aer_backend.run.return_value.result.return_value.get_counts.return_value = {"0": 1}
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = ValueError("Not configured")
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_aer.from_backend.return_value = aer_backend
+
+        provider = LocalProvider()
+        provider.get_devices()
+        device = provider._devices["fake_torino"]
+
+        mock_aer.from_backend.assert_not_called()
+        job = device.submit(MagicMock(), shots=1)
+
+        mock_aer.from_backend.assert_called_once_with(mock_backend)
+        assert job.result().data.measurement_counts == {"0": 1}
+
+
+def test_listed_fake_backend_profile_matches_eager_aer_configuration():
+    """A listed lazy fake backend should expose the same profile fields as eager Aer."""
+    fake_backend = next(
+        backend
+        for backend in LocalProvider._load_fake_local_backends().values()
+        if backend.name == "fake_torino"
+    )
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+    ):
+        mock_service.side_effect = ValueError("Not configured")
+        mock_fake_provider.return_value.backends.return_value = [fake_backend]
+        listed_provider = LocalProvider()
+        listed_provider.get_devices()
+        listed_device = listed_provider.get_device("fake_torino")
+
+    lazy_backend = listed_device._backend
+    lazy_config = lazy_backend.configuration()
+    eager_config = AerSimulator.from_backend(fake_backend).configuration()
+
+    assert lazy_backend._aer_backend is None
+    missing = object()
+    for field in (
+        "backend_name",
+        "backend_version",
+        "n_qubits",
+        "num_qubits",
+        "basis_gates",
+        "gates",
+        "max_shots",
+        "coupling_map",
+        "max_experiments",
+        "description",
+    ):
+        assert getattr(lazy_config, field, missing) == getattr(eager_config, field, missing)
+
+
+def test_listed_fake_backend_forwards_unknown_attributes_to_materialized_aer():
+    mock_backend = _mock_backend("fake_torino", num_qubits=133)
+    aer_backend = _mock_aer_backend(num_qubits=133)
+    aer_backend.status.return_value = "online"
+
+    with (
+        patch("metriq_gym.local.provider.QiskitRuntimeService") as mock_service,
+        patch("metriq_gym.local.provider.FakeProviderForBackendV2") as mock_fake_provider,
+        patch("metriq_gym.local.provider.AerSimulator") as mock_aer,
+    ):
+        mock_service.side_effect = ValueError("Not configured")
+        mock_fake_provider.return_value.backends.return_value = [mock_backend]
+        mock_aer.from_backend.return_value = aer_backend
+
+        provider = LocalProvider()
+        provider.get_devices()
+        device = provider._devices["fake_torino"]
+
+        mock_aer.from_backend.assert_not_called()
+        assert device._backend.status() == "online"
+
+    mock_aer.from_backend.assert_called_once_with(mock_backend)
+
+
+def test_get_device_resolves_real_qiskit_fake_backend_alias_without_ibm_auth(monkeypatch):
+    fake_backend_names = sorted(
+        backend.name
+        for backend in LocalProvider._load_fake_local_backends().values()
+        if isinstance(backend.name, str) and backend.name.startswith("fake_")
+    )
+    if not fake_backend_names:
+        pytest.fail("FakeProviderForBackendV2 returned no fake_*-prefixed backends")
+
+    fake_backend_name = (
+        "fake_torino" if "fake_torino" in fake_backend_names else fake_backend_names[0]
+    )
+    ibm_device_id = fake_backend_name.replace("fake_", "ibm_", 1)
+
+    for key in (
+        "QISKIT_IBM_TOKEN",
+        "QISKIT_IBM_CHANNEL",
+        "QISKIT_IBM_INSTANCE",
+        "IBM_QUANTUM_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    class RuntimeServiceWithoutAccount:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def backend(self, *_args, **_kwargs):
+            raise ValueError("No IBM account configured")
+
+    monkeypatch.setattr(
+        "metriq_gym.local.provider.QiskitRuntimeService",
+        RuntimeServiceWithoutAccount,
+    )
+
+    device = LocalProvider().get_device(ibm_device_id)
+
+    assert isinstance(device, LocalAerDevice)
+    assert device.id == ibm_device_id
+    assert device.profile.simulator is True

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -128,6 +128,22 @@ def test_setup_device_invalid_device(mock_provider, patch_load_provider, caplog)
     assert "Devices available: device1, device2" in caplog.text
 
 
+def test_setup_device_unexpected_device_value_error_propagates(
+    mock_provider, patch_load_provider, caplog
+):
+    caplog.set_level(logging.INFO)
+    mock_provider.get_device.side_effect = ValueError("provider construction bug")
+    mock_provider.get_devices.return_value = [FakeDevice(id="device1"), FakeDevice(id="device2")]
+
+    provider_name = "test_provider"
+    backend_name = "non_existent_backend"
+
+    with pytest.raises(ValueError, match="provider construction bug"):
+        setup_device(provider_name, backend_name)
+
+    assert "Devices available" not in caplog.text
+
+
 def test_setup_device_empty_device(mock_provider, patch_load_provider, caplog):
     caplog.set_level(logging.INFO)
     mock_provider.get_device.side_effect = QbraidError()


### PR DESCRIPTION
## Summary

- Resolve IBM-style local device IDs such as `ibm_torino` to cached Qiskit fake backend snapshots when IBM Runtime credentials are unavailable.
- Support local fake-backend aliases such as `fake_torino`, `ibm_torino`, `ibm-torino`, `IBM_Torino`, and `torino`.
- Include local fake backend snapshots in `LocalProvider.get_devices()` without eagerly constructing every `AerSimulator`.
- Preserve the live IBM Runtime path when credentials are configured, dedupe live runtime backends against fake twins, and log runtime-discovery failures at debug level.
- Add regression coverage for no-auth lookup, listing, alias normalization, lazy profile synthesis, and setup-device error handling.

## Why

The issue reproduction dispatches a local job to `ibm_torino` without IBM credentials:

```bash
mgym job dispatch metriq_gym/schemas/examples/qml_kernel.example.json -p local -d ibm_torino
```

Today this can fall through to `QiskitRuntimeService().backend(...)`, causing IBM account discovery and failing even though cached fake backend snapshots are available locally.

This implements the issue's fake-provider fallback while keeping live IBM Runtime backend data when credentials are available.

Fixes #521 


## Testing

- uv run pytest tests/unit -q      # 356 passed
- uv run ruff check .
- uv run mypy metriq_gym
- uv run pytest tests/e2e -q       # 15 passed
- No-auth smoke with an empty home and IBM env vars unset:
  - `LocalProvider().get_device("ibm_torino")` returned a 133-qubit local simulator.
  - `LocalProvider().get_devices()` listed local fake snapshots, including Torino, without IBM credentials.
  
## AI assistance disclosure

I used Codex, Claude, and Hermes as AI assistants to investigate the issue path, prototype and review the patch, compare related PRs, prepare tests, and draft this PR text. I manually reviewed the final diff and validation results. The implementation and PR are submitted with human oversight; any remaining mistakes are mine.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
