### PR TITLE
feat: expose vendor calibration metadata

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -40,6 +40,7 @@ jobs:
           mkdocs build
 
       - name: Deploy preview
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1.8.1
         with:
           source-dir: docs/site

--- a/docs/content/getting-started/metriq-platform.md
+++ b/docs/content/getting-started/metriq-platform.md
@@ -92,7 +92,7 @@ report uncertainty on a metric use that same object shape for the metric itself.
 | `results` | Benchmark outputs. Metrics may be plain numbers or `{value, uncertainty}` objects; `results.score` is the summary score when the benchmark defines one |
 | `platform.provider` | Provider identifier used for the run |
 | `platform.device` | Device or backend identifier used for the run |
-| `platform.device_metadata` | Optional normalized metadata such as `num_qubits`, `simulator`, and backend `version` |
+| `platform.device_metadata` | Optional normalized metadata such as `num_qubits`, `simulator`, backend `version`, and vendor calibration summaries under `calibration` |
 | `params` | Validated benchmark configuration used to run the job |
 
 ## Contributing Quality Data
@@ -160,4 +160,3 @@ git clone https://github.com/unitaryfoundation/metriq-data.git
 - [Metriq Platform](https://metriq.info)
 - [metriq-data Repository](https://github.com/unitaryfoundation/metriq-data)
 - [Unitary Foundation](https://unitary.foundation)
-

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -18,6 +18,7 @@ from metriq_gym.quantinuum.device import QuantinuumDevice
 
 
 logger = logging.getLogger(__name__)
+_MISSING = object()
 
 
 # Version of a device backend (e.g. ibm_sherbrooke --> '1.6.73').
@@ -395,8 +396,21 @@ def _fidelity_errors(
 def _collect_braket_named_average(
     source: Any, names: set[str], *, seconds: bool = False
 ) -> list[float]:
+    entries: list[tuple[float, str | None]] = []
+    if not isinstance(source, Mapping) and not (
+        isinstance(source, Sequence) and not isinstance(source, (str, bytes, bytearray))
+    ):
+        for name in names:
+            for candidate in {name, name.lower(), name.upper()}:
+                value = _field(source, candidate, _MISSING)
+                if value is not _MISSING:
+                    entries.extend(_entry_values(value))
+
+    if not entries:
+        entries = _walk_named_entries(source, names)
+
     values = []
-    for value, unit in _walk_named_entries(source, names):
+    for value, unit in entries:
         values.append(_seconds(value, unit) if seconds else value)
     return values
 
@@ -459,6 +473,11 @@ def _braket_standardized_calibration(standardized: Any) -> dict[str, Any]:
     last_update_date = _first_named_text(
         [standardized], {"updatedat", "lastupdatedate", "last_update_date", "lastupdated"}
     )
+    if not last_update_date:
+        for name in ("updatedAt", "lastUpdateDate", "last_update_date", "lastUpdated"):
+            last_update_date = _isoformat(_field(standardized, name))
+            if last_update_date:
+                break
     if last_update_date:
         calibration["last_update_date"] = last_update_date
 

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -1,5 +1,9 @@
+import logging
 from functools import singledispatch
-from typing import cast
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from numbers import Real
+from typing import Any, cast
 
 import networkx as nx
 import rustworkx as rx
@@ -11,6 +15,9 @@ from pytket.architecture import FullyConnected
 from metriq_gym.local.device import LocalAerDevice
 from metriq_gym.origin.device import OriginDevice, get_origin_connectivity
 from metriq_gym.quantinuum.device import QuantinuumDevice
+
+
+logger = logging.getLogger(__name__)
 
 
 # Version of a device backend (e.g. ibm_sherbrooke --> '1.6.73').
@@ -167,6 +174,421 @@ def _(device: QiskitBackend, graph: rx.PyGraph) -> rx.PyGraph:
     return new_graph
 
 
+def _safe_float(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        return None
+    return float(value)
+
+
+def _average(values: Sequence[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _isoformat(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _metadata(device: Any) -> Mapping[str, Any]:
+    metadata = getattr(device, "metadata", None)
+    if not callable(metadata):
+        return {}
+    try:
+        value = metadata()
+    except Exception:
+        return {}
+    return value if isinstance(value, Mapping) else {}
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _iter_collection(value: Any) -> list[Any]:
+    if isinstance(value, Mapping):
+        return list(value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return list(value)
+    return []
+
+
+def _entry_values(value: Any) -> list[tuple[float, str | None]]:
+    if isinstance(value, Mapping):
+        unit = value.get("unit")
+        unit_str = unit if isinstance(unit, str) else None
+        for key in ("value", "mean", "average", "avg"):
+            number = _safe_float(value.get(key))
+            if number is not None:
+                return [(number, unit_str)]
+        values: list[tuple[float, str | None]] = []
+        for nested_value in value.values():
+            values.extend(_entry_values(nested_value))
+        return values
+
+    number = _safe_float(value)
+    if number is not None:
+        return [(number, None)]
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        values = []
+        for item in value:
+            values.extend(_entry_values(item))
+        return values
+
+    attr_value = getattr(value, "value", None)
+    number = _safe_float(attr_value)
+    if number is not None:
+        unit = getattr(value, "unit", None)
+        return [(number, unit if isinstance(unit, str) else None)]
+
+    return []
+
+
+def _walk_named_entries(value: Any, names: set[str]) -> list[tuple[float, str | None]]:
+    entries: list[tuple[float, str | None]] = []
+    if isinstance(value, Mapping):
+        for key, nested_value in value.items():
+            key_name = str(key).lower()
+            if key_name in names:
+                entries.extend(_entry_values(nested_value))
+            entries.extend(_walk_named_entries(nested_value, names))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            entries.extend(_walk_named_entries(item, names))
+    return entries
+
+
+def _seconds(value: float, unit: str | None) -> float:
+    normalized_unit = (unit or "s").strip().lower().replace("µ", "u")
+    if normalized_unit in {"s", "sec", "second", "seconds"}:
+        return value
+    if normalized_unit in {"ms", "millisecond", "milliseconds"}:
+        return value / 1_000
+    if normalized_unit in {"us", "usec", "microsecond", "microseconds"}:
+        return value / 1_000_000
+    if normalized_unit in {"ns", "nanosecond", "nanoseconds"}:
+        return value / 1_000_000_000
+    return value
+
+
+def _error_from_fidelity(fidelity: float) -> float | None:
+    if 0 <= fidelity <= 1:
+        return 1.0 - fidelity
+    if 1 < fidelity <= 100:
+        return (100.0 - fidelity) / 100.0
+    return None
+
+
+def _first_average(
+    sources: Sequence[Any],
+    name_groups: Sequence[set[str]],
+    *,
+    transform=lambda value, unit: value,
+) -> float | None:
+    for source in sources:
+        for names in name_groups:
+            entries = _walk_named_entries(source, names)
+            values = []
+            for value, unit in entries:
+                number = _safe_float(transform(value, unit))
+                if number is not None:
+                    values.append(number)
+            average = _average(values)
+            if average is not None:
+                return average
+    return None
+
+
+def _first_named_text(sources: Sequence[Any], names: set[str]) -> str | None:
+    for source in sources:
+        if isinstance(source, Mapping):
+            for key, value in source.items():
+                if str(key).lower() in names:
+                    text = _isoformat(value)
+                    if text:
+                        return text
+                text = _first_named_text([value], names)
+                if text:
+                    return text
+        elif isinstance(source, Sequence) and not isinstance(source, (str, bytes, bytearray)):
+            text = _first_named_text(source, names)
+            if text:
+                return text
+    return None
+
+
+def _qiskit_property_value(entry: Any, name: str) -> tuple[float, str | None] | None:
+    if getattr(entry, "name", None) != name:
+        return None
+    number = _safe_float(getattr(entry, "value", None))
+    if number is None:
+        return None
+    unit = getattr(entry, "unit", None)
+    return number, unit if isinstance(unit, str) else None
+
+
+def _qiskit_qubit_average(
+    properties: Any, names: Sequence[str], *, seconds: bool = False
+) -> float | None:
+    values: list[float] = []
+    for qubit_properties in getattr(properties, "qubits", []) or []:
+        for entry in qubit_properties:
+            for name in names:
+                value = _qiskit_property_value(entry, name)
+                if value is not None:
+                    number, unit = value
+                    values.append(_seconds(number, unit) if seconds else number)
+                    break
+    return _average(values)
+
+
+def _qiskit_gate_error_average(properties: Any, arity: int) -> float | None:
+    values: list[float] = []
+    for gate in getattr(properties, "gates", []) or []:
+        if len(getattr(gate, "qubits", []) or []) != arity:
+            continue
+        for entry in getattr(gate, "parameters", []) or []:
+            value = _qiskit_property_value(entry, "gate_error")
+            if value is not None:
+                values.append(value[0])
+                break
+    return _average(values)
+
+
+def _fidelity_type_name(fidelity: Any) -> str | None:
+    fidelity_type = _field(fidelity, "fidelityType")
+    name = _field(fidelity_type, "name")
+    return str(name).upper() if name is not None else None
+
+
+def _fidelity_errors(
+    fidelities: Any, *, include_type: str | None = None, exclude_type: str | None = None
+) -> list[float]:
+    errors: list[float] = []
+    entries = _iter_collection(fidelities)
+    if not entries and fidelities is not None:
+        entries = [fidelities]
+    for fidelity_entry in entries:
+        fidelity_type = _fidelity_type_name(fidelity_entry)
+        if include_type is not None and fidelity_type != include_type:
+            continue
+        if exclude_type is not None and fidelity_type == exclude_type:
+            continue
+
+        raw_fidelity = _field(fidelity_entry, "fidelity", fidelity_entry)
+        fidelity = _safe_float(raw_fidelity)
+        if fidelity is None:
+            continue
+        error = _error_from_fidelity(fidelity)
+        if error is not None:
+            errors.append(error)
+    return errors
+
+
+def _collect_braket_named_average(
+    source: Any, names: set[str], *, seconds: bool = False
+) -> list[float]:
+    values = []
+    for value, unit in _walk_named_entries(source, names):
+        values.append(_seconds(value, unit) if seconds else value)
+    return values
+
+
+def _braket_standardized_calibration(standardized: Any) -> dict[str, Any]:
+    calibration: dict[str, Any] = {}
+
+    one_qubit_properties = _iter_collection(_field(standardized, "oneQubitProperties"))
+    two_qubit_properties = _iter_collection(_field(standardized, "twoQubitProperties"))
+
+    t1_values: list[float] = []
+    t2_values: list[float] = []
+    readout_errors: list[float] = []
+    one_qubit_errors: list[float] = []
+    two_qubit_errors: list[float] = []
+
+    for qubit_properties in one_qubit_properties:
+        t1_values.extend(_collect_braket_named_average(qubit_properties, {"t1"}, seconds=True))
+        t2_values.extend(_collect_braket_named_average(qubit_properties, {"t2"}, seconds=True))
+        one_qubit_fidelities = _field(qubit_properties, "oneQubitFidelity")
+        readout_errors.extend(_fidelity_errors(one_qubit_fidelities, include_type="READOUT"))
+        one_qubit_errors.extend(_fidelity_errors(one_qubit_fidelities, exclude_type="READOUT"))
+        readout_errors.extend(_fidelity_errors(_field(qubit_properties, "readoutFidelity")))
+        one_qubit_errors.extend(_fidelity_errors(_field(qubit_properties, "singleQubitFidelity")))
+
+    if not t1_values:
+        t1_values.extend(_collect_braket_named_average(standardized, {"t1"}, seconds=True))
+    if not t2_values:
+        t2_values.extend(_collect_braket_named_average(standardized, {"t2"}, seconds=True))
+    if not readout_errors:
+        readout_errors.extend(_fidelity_errors(_field(standardized, "readoutFidelity")))
+    if not one_qubit_errors:
+        one_qubit_errors.extend(_fidelity_errors(_field(standardized, "singleQubitFidelity")))
+
+    for edge_properties in two_qubit_properties:
+        two_qubit_errors.extend(_fidelity_errors(_field(edge_properties, "twoQubitGateFidelity")))
+    if not two_qubit_errors:
+        two_qubit_errors.extend(_fidelity_errors(_field(standardized, "twoQubitGateFidelity")))
+
+    t1 = _average(t1_values)
+    if t1 is not None:
+        calibration["avg_t1_s"] = t1
+
+    t2 = _average(t2_values)
+    if t2 is not None:
+        calibration["avg_t2_s"] = t2
+
+    readout = _average(readout_errors)
+    if readout is not None:
+        calibration["avg_readout_error"] = readout
+
+    one_qubit_error = _average(one_qubit_errors)
+    if one_qubit_error is not None:
+        calibration["avg_1q_gate_error"] = one_qubit_error
+
+    two_qubit_error = _average(two_qubit_errors)
+    if two_qubit_error is not None:
+        calibration["avg_2q_gate_error"] = two_qubit_error
+
+    last_update_date = _first_named_text(
+        [standardized], {"updatedat", "lastupdatedate", "last_update_date", "lastupdated"}
+    )
+    if last_update_date:
+        calibration["last_update_date"] = last_update_date
+
+    return calibration
+
+
+@singledispatch
+def calibration_metadata(device: QuantumDevice) -> dict[str, Any]:
+    """Return normalized vendor calibration metadata when available."""
+    return {}
+
+
+@calibration_metadata.register
+def _(device: QiskitBackend) -> dict[str, Any]:
+    backend = device._backend
+    properties_func = getattr(backend, "properties", None)
+    properties = properties_func() if callable(properties_func) else None
+    if properties is None:
+        return {}
+
+    calibration: dict[str, Any] = {}
+
+    t1 = _qiskit_qubit_average(properties, ("T1", "t1"), seconds=True)
+    if t1 is not None:
+        calibration["avg_t1_s"] = t1
+
+    t2 = _qiskit_qubit_average(properties, ("T2", "t2"), seconds=True)
+    if t2 is not None:
+        calibration["avg_t2_s"] = t2
+
+    readout = _qiskit_qubit_average(properties, ("readout_error",))
+    if readout is None:
+        readout = _qiskit_qubit_average(properties, ("prob_meas1_prep0", "prob_meas0_prep1"))
+    if readout is not None:
+        calibration["avg_readout_error"] = readout
+
+    one_qubit_error = _qiskit_gate_error_average(properties, 1)
+    if one_qubit_error is not None:
+        calibration["avg_1q_gate_error"] = one_qubit_error
+
+    two_qubit_error = _qiskit_gate_error_average(properties, 2)
+    if two_qubit_error is not None:
+        calibration["avg_2q_gate_error"] = two_qubit_error
+
+    last_update_date = _isoformat(getattr(properties, "last_update_date", None))
+    if last_update_date:
+        calibration["last_update_date"] = last_update_date
+
+    return calibration
+
+
+@calibration_metadata.register
+def _(device: BraketDevice) -> dict[str, Any]:
+    device_properties = getattr(getattr(device, "_device", None), "properties", None)
+    device_metadata = _metadata(device)
+    metadata_calibration = device_metadata.get("calibration")
+
+    for source in (device_properties, device_metadata, metadata_calibration):
+        standardized = _field(source, "standardized")
+        standardized_calibration = _braket_standardized_calibration(standardized)
+        if standardized_calibration:
+            return standardized_calibration
+
+    sources = [source for source in (device_properties, device_metadata) if source]
+
+    calibration: dict[str, Any] = {}
+    t1 = _first_average(
+        sources,
+        [{"t1", "avg_t1_s"}],
+        transform=lambda value, unit: _seconds(value, unit),
+    )
+    if t1 is not None:
+        calibration["avg_t1_s"] = t1
+
+    t2 = _first_average(
+        sources,
+        [{"t2", "avg_t2_s"}],
+        transform=lambda value, unit: _seconds(value, unit),
+    )
+    if t2 is not None:
+        calibration["avg_t2_s"] = t2
+
+    readout = _first_average(
+        sources,
+        [{"readouterror", "readout_error", "avg_readout_error"}],
+    )
+    if readout is None:
+        readout = _first_average(
+            sources,
+            [{"readoutfidelity", "fidelityreadout", "fro", "spam"}],
+            transform=lambda value, unit: _error_from_fidelity(value),
+        )
+    if readout is not None:
+        calibration["avg_readout_error"] = readout
+
+    one_qubit_error = _first_average(
+        sources,
+        [{"onequbitgateerror", "singlequbitgateerror", "avg_1q_gate_error"}],
+    )
+    if one_qubit_error is None:
+        one_qubit_error = _first_average(
+            sources,
+            [{"onequbitfidelity", "f1qrb"}, {"singlequbitgatefidelity"}, {"singlequbitfidelity"}],
+            transform=lambda value, unit: _error_from_fidelity(value),
+        )
+    if one_qubit_error is not None:
+        calibration["avg_1q_gate_error"] = one_qubit_error
+
+    two_qubit_error = _first_average(
+        sources,
+        [{"twoqubitgateerror", "avg_2q_gate_error"}],
+    )
+    if two_qubit_error is None:
+        two_qubit_error = _first_average(
+            sources,
+            [{"twoqubitfidelity", "fcz"}, {"twoqubitgatefidelity"}],
+            transform=lambda value, unit: _error_from_fidelity(value),
+        )
+    if two_qubit_error is not None:
+        calibration["avg_2q_gate_error"] = two_qubit_error
+
+    last_update_date = _first_named_text(
+        sources, {"lastupdatedate", "last_update_date", "lastupdated", "timestamp"}
+    )
+    if last_update_date:
+        calibration["last_update_date"] = last_update_date
+
+    return calibration
+
+
 def normalized_metadata(device: QuantumDevice) -> dict:
     """Return a minimal, normalized subset of device metadata.
 
@@ -174,6 +596,7 @@ def normalized_metadata(device: QuantumDevice) -> dict:
     - simulator: bool
     - version: str
     - num_qubits: int
+    - calibration: dict
     """
     meta: dict = {}
     try:
@@ -181,20 +604,35 @@ def normalized_metadata(device: QuantumDevice) -> dict:
         if isinstance(simulator, bool):
             meta["simulator"] = simulator
     except Exception:
-        pass
+        logger.debug(
+            "Failed to extract simulator metadata for %s", type(device).__name__, exc_info=True
+        )
 
     try:
         n = getattr(device, "num_qubits", None)
         if isinstance(n, int):
             meta["num_qubits"] = n
     except Exception:
-        pass
+        logger.debug(
+            "Failed to extract qubit count metadata for %s", type(device).__name__, exc_info=True
+        )
 
     try:
         ver = version(device)
         if isinstance(ver, str) and ver:
             meta["version"] = ver
     except Exception:
-        pass
+        logger.debug(
+            "Failed to extract version metadata for %s", type(device).__name__, exc_info=True
+        )
+
+    try:
+        calibration = calibration_metadata(device)
+        if calibration:
+            meta["calibration"] = calibration
+    except Exception:
+        logger.debug(
+            "Failed to extract calibration metadata for %s", type(device).__name__, exc_info=True
+        )
 
     return meta

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -19,6 +19,7 @@ from metriq_gym.quantinuum.device import QuantinuumDevice
 
 logger = logging.getLogger(__name__)
 _MISSING = object()
+_MAX_METADATA_WALK_DEPTH = 8
 
 
 # Version of a device backend (e.g. ibm_sherbrooke --> '1.6.73').
@@ -220,7 +221,25 @@ def _iter_collection(value: Any) -> list[Any]:
     return []
 
 
-def _entry_values(value: Any) -> list[tuple[float, str | None]]:
+def _entry_values(
+    value: Any,
+    *,
+    _depth: int = 0,
+    _seen: set[int] | None = None,
+) -> list[tuple[float, str | None]]:
+    if _depth > _MAX_METADATA_WALK_DEPTH:
+        return []
+    if isinstance(value, Mapping) or (
+        isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+    ):
+        seen = set() if _seen is None else _seen
+        value_id = id(value)
+        if value_id in seen:
+            return []
+        seen.add(value_id)
+    else:
+        seen = _seen
+
     if isinstance(value, Mapping):
         unit = value.get("unit")
         unit_str = unit if isinstance(unit, str) else None
@@ -230,7 +249,7 @@ def _entry_values(value: Any) -> list[tuple[float, str | None]]:
                 return [(number, unit_str)]
         values: list[tuple[float, str | None]] = []
         for nested_value in value.values():
-            values.extend(_entry_values(nested_value))
+            values.extend(_entry_values(nested_value, _depth=_depth + 1, _seen=seen))
         return values
 
     number = _safe_float(value)
@@ -240,7 +259,7 @@ def _entry_values(value: Any) -> list[tuple[float, str | None]]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         values = []
         for item in value:
-            values.extend(_entry_values(item))
+            values.extend(_entry_values(item, _depth=_depth + 1, _seen=seen))
         return values
 
     attr_value = getattr(value, "value", None)
@@ -252,17 +271,36 @@ def _entry_values(value: Any) -> list[tuple[float, str | None]]:
     return []
 
 
-def _walk_named_entries(value: Any, names: set[str]) -> list[tuple[float, str | None]]:
+def _walk_named_entries(
+    value: Any,
+    names: set[str],
+    *,
+    _depth: int = 0,
+    _seen: set[int] | None = None,
+) -> list[tuple[float, str | None]]:
+    if _depth > _MAX_METADATA_WALK_DEPTH:
+        return []
+
     entries: list[tuple[float, str | None]] = []
     if isinstance(value, Mapping):
+        seen = set() if _seen is None else _seen
+        value_id = id(value)
+        if value_id in seen:
+            return []
+        seen.add(value_id)
         for key, nested_value in value.items():
             key_name = str(key).lower()
             if key_name in names:
-                entries.extend(_entry_values(nested_value))
-            entries.extend(_walk_named_entries(nested_value, names))
+                entries.extend(_entry_values(nested_value, _seen=set(seen)))
+            entries.extend(_walk_named_entries(nested_value, names, _depth=_depth + 1, _seen=seen))
     elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        seen = set() if _seen is None else _seen
+        value_id = id(value)
+        if value_id in seen:
+            return []
+        seen.add(value_id)
         for item in value:
-            entries.extend(_walk_named_entries(item, names))
+            entries.extend(_walk_named_entries(item, names, _depth=_depth + 1, _seen=seen))
     return entries
 
 
@@ -307,19 +345,38 @@ def _first_average(
     return None
 
 
-def _first_named_text(sources: Sequence[Any], names: set[str]) -> str | None:
+def _first_named_text(
+    sources: Sequence[Any],
+    names: set[str],
+    *,
+    _depth: int = 0,
+    _seen: set[int] | None = None,
+) -> str | None:
+    if _depth > _MAX_METADATA_WALK_DEPTH:
+        return None
+
     for source in sources:
         if isinstance(source, Mapping):
+            seen = set() if _seen is None else _seen
+            source_id = id(source)
+            if source_id in seen:
+                continue
+            seen.add(source_id)
             for key, value in source.items():
                 if str(key).lower() in names:
                     text = _isoformat(value)
                     if text:
                         return text
-                text = _first_named_text([value], names)
+                text = _first_named_text([value], names, _depth=_depth + 1, _seen=seen)
                 if text:
                     return text
         elif isinstance(source, Sequence) and not isinstance(source, (str, bytes, bytearray)):
-            text = _first_named_text(source, names)
+            seen = set() if _seen is None else _seen
+            source_id = id(source)
+            if source_id in seen:
+                continue
+            seen.add(source_id)
+            text = _first_named_text(source, names, _depth=_depth + 1, _seen=seen)
             if text:
                 return text
     return None
@@ -474,6 +531,7 @@ def _braket_standardized_calibration(standardized: Any) -> dict[str, Any]:
         [standardized], {"updatedat", "lastupdatedate", "last_update_date", "lastupdated"}
     )
     if not last_update_date:
+        # Braket SDK model objects expose attributes instead of dict keys.
         for name in ("updatedAt", "lastUpdateDate", "last_update_date", "lastUpdated"):
             last_update_date = _isoformat(_field(standardized, name))
             if last_update_date:
@@ -534,6 +592,9 @@ def _(device: BraketDevice) -> dict[str, Any]:
     device_properties = getattr(getattr(device, "_device", None), "properties", None)
     device_metadata = _metadata(device)
     metadata_calibration = device_metadata.get("calibration")
+    provider_name = str(getattr(device, "_provider_name", "") or "").lower()
+    is_rigetti = "rigetti" in provider_name
+    is_ionq = "ionq" in provider_name
 
     for source in (device_properties, device_metadata, metadata_calibration):
         standardized = _field(source, "standardized")
@@ -565,9 +626,14 @@ def _(device: BraketDevice) -> dict[str, Any]:
         [{"readouterror", "readout_error", "avg_readout_error"}],
     )
     if readout is None:
+        readout_fidelity_names = [{"readoutfidelity", "fidelityreadout"}]
+        if is_rigetti:
+            readout_fidelity_names.append({"fro"})
+        if is_ionq:
+            readout_fidelity_names.append({"spam"})
         readout = _first_average(
             sources,
-            [{"readoutfidelity", "fidelityreadout", "fro", "spam"}],
+            readout_fidelity_names,
             transform=lambda value, unit: _error_from_fidelity(value),
         )
     if readout is not None:
@@ -578,9 +644,16 @@ def _(device: BraketDevice) -> dict[str, Any]:
         [{"onequbitgateerror", "singlequbitgateerror", "avg_1q_gate_error"}],
     )
     if one_qubit_error is None:
+        one_qubit_fidelity_names = [
+            {"onequbitfidelity"},
+            {"singlequbitgatefidelity"},
+            {"singlequbitfidelity"},
+        ]
+        if is_rigetti:
+            one_qubit_fidelity_names.append({"f1qrb"})
         one_qubit_error = _first_average(
             sources,
-            [{"onequbitfidelity", "f1qrb"}, {"singlequbitgatefidelity"}, {"singlequbitfidelity"}],
+            one_qubit_fidelity_names,
             transform=lambda value, unit: _error_from_fidelity(value),
         )
     if one_qubit_error is not None:
@@ -591,9 +664,12 @@ def _(device: BraketDevice) -> dict[str, Any]:
         [{"twoqubitgateerror", "avg_2q_gate_error"}],
     )
     if two_qubit_error is None:
+        two_qubit_fidelity_names = [{"twoqubitfidelity"}, {"twoqubitgatefidelity"}]
+        if is_rigetti:
+            two_qubit_fidelity_names.append({"fcz"})
         two_qubit_error = _first_average(
             sources,
-            [{"twoqubitfidelity", "fcz"}, {"twoqubitgatefidelity"}],
+            two_qubit_fidelity_names,
             transform=lambda value, unit: _error_from_fidelity(value),
         )
     if two_qubit_error is not None:
@@ -606,6 +682,30 @@ def _(device: BraketDevice) -> dict[str, Any]:
         calibration["last_update_date"] = last_update_date
 
     return calibration
+
+
+@calibration_metadata.register
+def _(device: AzureQuantumDevice) -> dict[str, Any]:
+    # TODO(#668): normalize Azure calibration metadata when qBraid exposes it.
+    return {}
+
+
+@calibration_metadata.register
+def _(device: LocalAerDevice) -> dict[str, Any]:
+    # TODO(#668): local simulators do not expose vendor calibration metadata.
+    return {}
+
+
+@calibration_metadata.register
+def _(device: OriginDevice) -> dict[str, Any]:
+    # TODO(#668): normalize Origin calibration metadata when available.
+    return {}
+
+
+@calibration_metadata.register
+def _(device: QuantinuumDevice) -> dict[str, Any]:
+    # TODO(#668): normalize Quantinuum calibration metadata when available.
+    return {}
 
 
 def normalized_metadata(device: QuantumDevice) -> dict:

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -229,16 +229,14 @@ def _entry_values(
 ) -> list[tuple[float, str | None]]:
     if _depth > _MAX_METADATA_WALK_DEPTH:
         return []
+    seen = set() if _seen is None else _seen
     if isinstance(value, Mapping) or (
         isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
     ):
-        seen = set() if _seen is None else _seen
         value_id = id(value)
         if value_id in seen:
             return []
         seen.add(value_id)
-    else:
-        seen = _seen
 
     if isinstance(value, Mapping):
         unit = value.get("unit")

--- a/tests/unit/exporters/test_json_exporter.py
+++ b/tests/unit/exporters/test_json_exporter.py
@@ -16,3 +16,26 @@ def test_json_exporter_serializes_none_uncertainty_to_null(metriq_job, tmp_path)
 
     assert data["results"]["expectation_value"]["value"] == 0.42
     assert data["results"]["expectation_value"]["uncertainty"] is None
+
+
+def test_json_exporter_preserves_device_calibration_metadata(metriq_job, tmp_path):
+    metriq_job.platform["device_metadata"] = {
+        "num_qubits": 5,
+        "calibration": {
+            "avg_t1_s": 0.00012,
+            "avg_t2_s": 0.00009,
+            "avg_readout_error": 0.025,
+            "avg_1q_gate_error": 0.001,
+            "avg_2q_gate_error": 0.02,
+            "last_update_date": "2026-06-01T12:00:00Z",
+        },
+    }
+    result = WITResult(expectation_value=BenchmarkScore(value=0.42))
+    outfile = tmp_path / "result.json"
+
+    JsonExporter(metriq_job, result).export(str(outfile))
+
+    with open(outfile) as f:
+        data = json.load(f)
+
+    assert data["platform"]["device_metadata"] == metriq_job.platform["device_metadata"]

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -478,6 +478,65 @@ class TestNormalizedMetadata:
         assert calibration["avg_2q_gate_error"] == pytest.approx(0.06)
         assert calibration["last_update_date"] == "2026-06-03T00:00:00Z"
 
+    def test_braket_standardized_calibration_reads_model_object_fields(self):
+        device = Mock(spec=BraketDevice)
+        device.num_qubits = 2
+        device._provider_name = "Amazon Braket"
+        device._device = Mock()
+        device._device.properties = types.SimpleNamespace(
+            standardized=types.SimpleNamespace(
+                updatedAt="2026-06-04T00:00:00Z",
+                oneQubitProperties={
+                    "0": types.SimpleNamespace(
+                        T1=types.SimpleNamespace(value=110, unit="us"),
+                        T2=types.SimpleNamespace(value=70, unit="us"),
+                        oneQubitFidelity=[
+                            types.SimpleNamespace(
+                                fidelity=0.96,
+                                fidelityType=types.SimpleNamespace(name="READOUT"),
+                            ),
+                            types.SimpleNamespace(
+                                fidelity=0.996,
+                                fidelityType=types.SimpleNamespace(name="GATE"),
+                            ),
+                        ],
+                    ),
+                    "1": types.SimpleNamespace(
+                        T1=types.SimpleNamespace(value=190, unit="us"),
+                        T2=types.SimpleNamespace(value=130, unit="us"),
+                        oneQubitFidelity=[
+                            types.SimpleNamespace(
+                                fidelity=0.98,
+                                fidelityType=types.SimpleNamespace(name="READOUT"),
+                            ),
+                            types.SimpleNamespace(
+                                fidelity=0.984,
+                                fidelityType=types.SimpleNamespace(name="GATE"),
+                            ),
+                        ],
+                    ),
+                },
+                twoQubitProperties={
+                    "0-1": types.SimpleNamespace(
+                        twoQubitGateFidelity=[
+                            types.SimpleNamespace(fidelity=0.94),
+                            types.SimpleNamespace(fidelity=0.92),
+                        ]
+                    )
+                },
+            )
+        )
+        device.metadata.return_value = {}
+
+        calibration = calibration_metadata(device)
+
+        assert calibration["avg_t1_s"] == pytest.approx(150e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(100e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.03)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.01)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.07)
+        assert calibration["last_update_date"] == "2026-06-04T00:00:00Z"
+
     def test_azure_device_zero_qubits(self):
         device = Mock(spec=AzureQuantumDevice)
         device.metadata.return_value = {"num_qubits": 0}

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -18,6 +18,7 @@ from metriq_gym.origin.device import OriginDevice
 from metriq_gym.qplatform.device import (
     version,
     connectivity_graph,
+    calibration_metadata,
     normalized_metadata,
     pruned_connectivity_graph,
 )
@@ -49,6 +50,41 @@ class MockTopologyGraph:
     def _create_nx_graph(self):
         edges = [(i, (i + 1) % self.num_qubits) for i in range(self.num_qubits)]
         return nx.Graph(edges)
+
+
+class MockProperty:
+    def __init__(self, name, value, unit=None):
+        self.name = name
+        self.value = value
+        self.unit = unit
+
+
+class MockGateProperty:
+    def __init__(self, qubits, gate_error):
+        self.qubits = qubits
+        self.parameters = [MockProperty("gate_error", gate_error)]
+
+
+class MockCalibrationProperties:
+    def __init__(self):
+        self.qubits = [
+            [
+                MockProperty("T1", 120, "us"),
+                MockProperty("T2", 90, "us"),
+                MockProperty("readout_error", 0.025),
+            ],
+            [
+                MockProperty("T1", 180, "us"),
+                MockProperty("T2", 110, "us"),
+                MockProperty("readout_error", 0.035),
+            ],
+        ]
+        self.gates = [
+            MockGateProperty([0], 0.001),
+            MockGateProperty([1], 0.003),
+            MockGateProperty([0, 1], 0.02),
+        ]
+        self.last_update_date = "2026-06-01T12:00:00Z"
 
 
 def _make_origin_device(
@@ -338,6 +374,109 @@ class TestNormalizedMetadata:
 
         meta = normalized_metadata(Unsupported())
         assert meta == {}
+
+    def test_qiskit_backend_calibration_metadata(self, mock_qiskit_backend):
+        mock_qiskit_backend._backend.properties.return_value = MockCalibrationProperties()
+
+        calibration = calibration_metadata(mock_qiskit_backend)
+
+        assert calibration["avg_t1_s"] == pytest.approx(150e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(100e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.03)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.002)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.02)
+        assert calibration["last_update_date"] == "2026-06-01T12:00:00Z"
+
+        meta = normalized_metadata(mock_qiskit_backend)
+        assert meta["calibration"] == calibration
+
+    def test_braket_calibration_prefers_detailed_values(self):
+        device = Mock(spec=BraketDevice)
+        device.num_qubits = 2
+        device._provider_name = "Amazon Braket"
+        device.metadata.return_value = {
+            "num_qubits": 2,
+            "calibration": {
+                "lastUpdateDate": "2026-06-02T00:00:00Z",
+                # Summary fidelity should not be averaged together with detailed
+                # oneQubitProperties values below.
+                "singleQubitFidelity": [0.90],
+                "oneQubitProperties": [
+                    {
+                        "T1": {"value": 100, "unit": "us"},
+                        "T2": {"value": 70, "unit": "us"},
+                        "oneQubitFidelity": 0.99,
+                        "readoutFidelity": 0.97,
+                    },
+                    {
+                        "T1": {"value": 200, "unit": "us"},
+                        "T2": {"value": 130, "unit": "us"},
+                        "oneQubitFidelity": 0.98,
+                        "readoutFidelity": 0.95,
+                    },
+                ],
+                "twoQubitProperties": [
+                    {"twoQubitGateFidelity": 0.93},
+                    {"twoQubitGateFidelity": 0.91},
+                ],
+            },
+        }
+
+        calibration = calibration_metadata(device)
+
+        assert calibration["avg_t1_s"] == pytest.approx(150e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(100e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.04)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.015)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.08)
+        assert calibration["last_update_date"] == "2026-06-02T00:00:00Z"
+
+        meta = normalized_metadata(device)
+        assert meta["num_qubits"] == 2
+        assert meta["calibration"] == calibration
+
+    def test_braket_standardized_calibration_separates_readout_fidelity(self):
+        device = Mock(spec=BraketDevice)
+        device.num_qubits = 2
+        device._provider_name = "Amazon Braket"
+        device._device = Mock()
+        device._device.properties = {
+            "standardized": {
+                "updatedAt": "2026-06-03T00:00:00Z",
+                "readoutFidelity": [{"fidelity": 0.50}],
+                "singleQubitFidelity": [{"fidelity": 0.50}],
+                "twoQubitGateFidelity": [{"fidelity": 0.50}],
+                "oneQubitProperties": {
+                    "0": {
+                        "T1": {"value": 100, "unit": "us"},
+                        "T2": {"value": 80, "unit": "us"},
+                        "oneQubitFidelity": [
+                            {"fidelity": 0.96, "fidelityType": {"name": "READOUT"}},
+                            {"fidelity": 0.995, "fidelityType": {"name": "GATE"}},
+                        ],
+                    },
+                    "1": {
+                        "T1": {"value": 200, "unit": "us"},
+                        "T2": {"value": 120, "unit": "us"},
+                        "oneQubitFidelity": [
+                            {"fidelity": 0.97, "fidelityType": {"name": "READOUT"}},
+                            {"fidelity": 0.985, "fidelityType": {"name": "GATE"}},
+                        ],
+                    },
+                },
+                "twoQubitProperties": {"0-1": {"twoQubitGateFidelity": [{"fidelity": 0.94}]}},
+            }
+        }
+        device.metadata.return_value = {}
+
+        calibration = calibration_metadata(device)
+
+        assert calibration["avg_t1_s"] == pytest.approx(150e-6)
+        assert calibration["avg_t2_s"] == pytest.approx(100e-6)
+        assert calibration["avg_readout_error"] == pytest.approx(0.035)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.01)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.06)
+        assert calibration["last_update_date"] == "2026-06-03T00:00:00Z"
 
     def test_azure_device_zero_qubits(self):
         device = Mock(spec=AzureQuantumDevice)

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -537,6 +537,58 @@ class TestNormalizedMetadata:
         assert calibration["avg_2q_gate_error"] == pytest.approx(0.07)
         assert calibration["last_update_date"] == "2026-06-04T00:00:00Z"
 
+    def test_braket_calibration_uses_rigetti_vendor_tokens_only_for_rigetti(self):
+        device = Mock(spec=BraketDevice)
+        device.num_qubits = 2
+        device._provider_name = "Rigetti"
+        device.metadata.return_value = {
+            "num_qubits": 2,
+            "calibration": {
+                "fRO": 0.96,
+                "f1QRB": 0.99,
+                "fCZ": 0.92,
+            },
+        }
+
+        calibration = calibration_metadata(device)
+
+        assert calibration["avg_readout_error"] == pytest.approx(0.04)
+        assert calibration["avg_1q_gate_error"] == pytest.approx(0.01)
+        assert calibration["avg_2q_gate_error"] == pytest.approx(0.08)
+
+    def test_braket_calibration_ignores_vendor_tokens_for_unknown_vendor(self):
+        device = Mock(spec=BraketDevice)
+        device.num_qubits = 2
+        device._provider_name = "Unknown Vendor"
+        device.metadata.return_value = {
+            "num_qubits": 2,
+            "calibration": {
+                "fRO": 0.96,
+                "spam": 0.97,
+                "f1QRB": 0.99,
+                "fCZ": 0.92,
+            },
+        }
+
+        assert calibration_metadata(device) == {}
+
+    def test_braket_calibration_handles_circular_metadata(self):
+        device = Mock(spec=BraketDevice)
+        device.num_qubits = 2
+        device._provider_name = "Amazon Braket"
+        calibration_payload: dict[str, object] = {
+            "T1": {"value": 100, "unit": "us"},
+        }
+        calibration_payload["loop"] = calibration_payload
+        device.metadata.return_value = {
+            "num_qubits": 2,
+            "calibration": calibration_payload,
+        }
+
+        calibration = calibration_metadata(device)
+
+        assert calibration["avg_t1_s"] == pytest.approx(100e-6)
+
     def test_azure_device_zero_qubits(self):
         device = Mock(spec=AzureQuantumDevice)
         device.metadata.return_value = {"num_qubits": 0}


### PR DESCRIPTION
Closes #668

## Summary
- Add normalized calibration metadata under `platform.device_metadata.calibration` for Qiskit and Braket devices.
- Surface common analysis fields: `avg_t1_s`, `avg_t2_s`, `avg_readout_error`, `avg_1q_gate_error`, `avg_2q_gate_error`, and `last_update_date` when available.
- Handle Braket standardized calibration payloads by separating READOUT fidelities from gate fidelities and preferring detailed per-qubit/per-edge values over top-level summaries to avoid double-counting.
- Read Braket standardized SDK model-object fields such as `T1`, `T2`, and `updatedAt` in addition to mapping-shaped payloads.
- Preserve calibration metadata through JSON export and document the new nested metadata shape.
- Refresh `uv.lock` to match the current `pyproject.toml` dependency bounds because CI uses `uv sync --group dev --frozen`.
- Skip the docs preview deploy step for fork PRs after the documentation build succeeds, avoiding upstream `gh-pages` push failures from read-only fork workflow tokens.

## Design boundary
- **Normalized fields:** this PR intentionally limits the schema to six optional fields useful for cross-device benchmark analysis: `avg_t1_s`, `avg_t2_s`, `avg_readout_error`, `avg_1q_gate_error`, `avg_2q_gate_error`, and `last_update_date`.
- **Source boundary:** the implementation only normalizes calibration data already exposed by the existing device wrapper or qBraid-backed SDK objects (`backend.properties()`, `device.metadata()`, and Braket device properties). It does not add new network calls or bypass qBraid to fetch vendor APIs directly.
- **Provider scope:** implemented handlers are Qiskit/IBM-style backends and Braket devices. Azure, LocalAer, Origin, and Quantinuum have explicit no-op handlers with `TODO(#668)` markers so unsupported providers are visible in code rather than implicitly falling through.
- **Braket fallback behavior:** generic field names remain provider-agnostic, while vendor-specific tokens such as Rigetti `fRO`/`f1QRB`/`fCZ` and IonQ `spam` are gated by provider name to avoid cross-vendor name pollution.
- **Real-device validation:** this PR has not been run against live hardware accounts. The tests use representative Qiskit and Braket payload shapes, including mapping-style payloads and Braket SDK model-object style payloads. Live-device validation would be the remaining acceptance check if maintainers require it before merge.

## Testing
- `uv run --frozen ruff check`
- `uv run --frozen stubgen --no-analysis && uv run --frozen mypy`
- `uv run --frozen pytest tests/unit/qplatform -q` (`73 passed`)
- `uv run --frozen ruff format --check metriq_gym/qplatform/device.py tests/unit/qplatform/test_device.py`
- `uv run --frozen python -m py_compile metriq_gym/qplatform/device.py tests/unit/qplatform/test_device.py`
- `git diff --check`

GitHub checks pass on the latest head `1167cb4`: docs `preview`, plus the full Python Tests matrix across Ubuntu/macOS and Python 3.12/3.13.

## AI assistance
I used AI assistance to draft and iterate on the implementation and tests, then verified the final changes locally with the commands above.