### PR TITLE
feat: add 2q gate counts

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,9 +1,9 @@
 import argparse
+from dataclasses import dataclass, field
 from typing import Iterable, TYPE_CHECKING, Protocol
 from abc import ABC
 
 from pydantic import BaseModel, computed_field
-from dataclasses import dataclass
 
 
 if TYPE_CHECKING:
@@ -27,6 +27,8 @@ class BenchmarkData:
     """Stores intermediate data from pre-processing and dispatching"""
 
     provider_job_ids: list[str]
+    input_two_qubit_gate_counts: list[int] = field(default_factory=list, kw_only=True)
+    transpiled_two_qubit_gate_counts: list[int] = field(default_factory=list, kw_only=True)
 
     @classmethod
     def from_quantum_job(cls, quantum_job, **kwargs):

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -47,7 +47,11 @@ from metriq_gym.qplatform.device import (
     connectivity_graph_for_gate,
     pruned_connectivity_graph,
 )
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import (
+    CircuitBatch,
+    two_qubit_gate_count,
+    two_qubit_gate_counts,
+)
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -390,13 +394,20 @@ class Clops(Benchmark):
         circuits = instantiate_circuits(
             template, parameters, self.params.num_circuits, seed=self.params.seed
         )
+        input_two_qubit_gate_counts = two_qubit_gate_counts(circuits)
         if isinstance(device, QiskitBackend) and self.params.use_session:
             return ClopsData.from_quantum_job(
                 self._submit_ibm_with_options(
                     device, circuits, shots=self.params.shots, use_session=self.params.use_session
-                )
+                ),
+                input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+                transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
             )
-        return ClopsData.from_quantum_job(device.run(circuits, shots=self.params.shots))
+        return ClopsData.from_quantum_job(
+            device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
+        )
 
     def _dispatch_parameterized(self, device: QiskitBackend) -> ClopsData:
         """Send a single parameterized circuit with parameter arrays.
@@ -414,8 +425,11 @@ class Clops(Benchmark):
         ]
 
         pub = (template, param_values, self.params.shots)
+        input_two_qubit_gate_counts = [two_qubit_gate_count(template)] * self.params.num_circuits
         return ClopsData.from_quantum_job(
-            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session)
+            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     def _dispatch_twirled(self, device: QiskitBackend) -> ClopsData:
@@ -427,6 +441,7 @@ class Clops(Benchmark):
         from qiskit_ibm_runtime.options import TwirlingOptions
 
         template, _parameters = self._build_template(device, parameterized=False)
+        input_two_qubit_gate_counts = [two_qubit_gate_count(template)] * self.params.num_circuits
 
         twirling_opts = TwirlingOptions(
             num_randomizations=self.params.num_circuits,
@@ -440,7 +455,9 @@ class Clops(Benchmark):
                 shots=self.params.shots * self.params.num_circuits,
                 twirling_options=twirling_opts,
                 use_session=self.params.use_session,
-            )
+            ),
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=input_two_qubit_gate_counts,
         )
 
     # ------------------------------------------------------------------

--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -26,6 +26,7 @@ import numpy as np
 import rustworkx as rx
 import time
 import warnings
+from qiskit import QuantumCircuit
 from qiskit_experiments.library.randomized_benchmarking import LayerFidelity
 from qiskit.result import Result as QiskitResult
 from qiskit.result.models import ExperimentResult, ExperimentResultData
@@ -39,7 +40,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
 )
 from metriq_gym.qplatform.device import connectivity_graph, connectivity_graph_for_gate
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -313,11 +314,18 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def _build_circuits(
         self, device: "QuantumDevice"
-    ) -> tuple[list, list[int], list[list[tuple[int, int]]], str, list[str]]:
+    ) -> tuple[
+        list[QuantumCircuit],
+        list[QuantumCircuit],
+        list[int],
+        list[list[tuple[int, int]]],
+        str,
+        list[str],
+    ]:
         """Build LayerFidelity circuits.
 
         Returns:
-            Tuple of (circuits, qubit_chain, two_disjoint_layers,
+            Tuple of (input_circuits, transpiled_circuits, qubit_chain, two_disjoint_layers,
                       two_qubit_gate, one_qubit_basis_gates).
         """
         num_qubits_in_chain = self.params.num_qubits_in_chain
@@ -356,21 +364,34 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
         )
 
         lfexp.experiment_options.max_circuits = 2 * num_samples * len(lengths)
+        input_circuits = lfexp.circuits()
         if self.params.decompose_clifford_ops:
-            circuits = lfexp._transpiled_circuits()
+            transpiled_circuits = lfexp._transpiled_circuits()
         else:
-            circuits = lfexp.circuits()
+            transpiled_circuits = input_circuits
 
-        return circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates
+        return (
+            input_circuits,
+            transpiled_circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+        )
 
     def dispatch_handler(self, device: "QuantumDevice") -> EPLGData:
         """Generate circuits, submit to device, return EPLGData."""
-        circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates = (
-            self._build_circuits(device)
-        )
+        (
+            input_circuits,
+            transpiled_circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+        ) = self._build_circuits(device)
 
         shots = self.params.shots
-        quantum_job = device.run(circuits, shots=shots)
+        quantum_job = device.run(transpiled_circuits, shots=shots)
 
         # Serialize the two_disjoint_layers as nested lists
         serialized_layers = [[list(edge) for edge in layer] for layer in two_disjoint_layers]
@@ -386,6 +407,8 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
             seed=self.params.seed,
             two_qubit_gate=two_qubit_gate,
             one_qubit_basis_gates=one_qubit_basis_gates,
+            input_two_qubit_gate_counts=two_qubit_gate_counts(input_circuits),
+            transpiled_two_qubit_gate_counts=two_qubit_gate_counts(transpiled_circuits),
         )
 
     def poll_handler(
@@ -478,5 +501,5 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def estimate_resources_handler(self, device: "QuantumDevice") -> list[CircuitBatch]:
         """Return circuit batches for resource estimation."""
-        circuits, _, _, _, _ = self._build_circuits(device)
-        return [CircuitBatch(circuits=circuits, shots=self.params.shots)]
+        _, transpiled_circuits, _, _, _, _ = self._build_circuits(device)
+        return [CircuitBatch(circuits=transpiled_circuits, shots=self.params.shots)]

--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -170,7 +170,6 @@ def calc_random_stats(num_qubits, graph_info, shots, num_random_trials, optimal_
 
 @dataclass
 class LinearRampQAOAData(BenchmarkData):
-    provider_job_ids: list[str]
     num_qubits: int
     graph_info: list[list]
     graph_type: GraphType

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -34,6 +34,12 @@ class BaseExporter(ABC):
             "job_type": self.metriq_gym_job.job_type.value,
             "results": results_block,
         }
+        for key in (
+            "input_two_qubit_gate_counts",
+            "transpiled_two_qubit_gate_counts",
+        ):
+            if key in self.metriq_gym_job.data:
+                record[key] = self.metriq_gym_job.data[key]
 
         runtime_seconds = getattr(self.metriq_gym_job, "runtime_seconds", None)
         if runtime_seconds is not None:

--- a/metriq_gym/resource_estimation.py
+++ b/metriq_gym/resource_estimation.py
@@ -77,6 +77,21 @@ def _count_gates(circuit: QuantumCircuit) -> GateCounts:
     return counts
 
 
+def count_gates(circuit: QuantumCircuit) -> GateCounts:
+    """Count circuit operations by the number of qubits they act on."""
+    return _count_gates(circuit)
+
+
+def two_qubit_gate_count(circuit: QuantumCircuit) -> int:
+    """Return the number of two-qubit gates in a circuit."""
+    return count_gates(circuit).two_qubit
+
+
+def two_qubit_gate_counts(circuits: Iterable[QuantumCircuit]) -> list[int]:
+    """Return the two-qubit gate count for each circuit."""
+    return [two_qubit_gate_count(circuit) for circuit in circuits]
+
+
 HQCFunction = Callable[[GateCounts, int, int], float]
 
 

--- a/tests/unit/benchmarks/test_benchmark.py
+++ b/tests/unit/benchmarks/test_benchmark.py
@@ -41,6 +41,26 @@ class TestBenchmarkData:
         assert data.provider_job_ids == [TEST_JOB_ID]
         assert data.extra == 42
 
+    def test_gate_count_fields_default_to_empty_lists(self):
+        data = BenchmarkData(provider_job_ids=["job"])
+
+        assert data.input_two_qubit_gate_counts == []
+        assert data.transpiled_two_qubit_gate_counts == []
+
+    def test_from_quantum_job_preserves_gate_count_kwargs(self):
+        mock_job = MagicMock(spec=QuantumJob)
+        mock_job.id = "job_with_counts"
+
+        data = BenchmarkData.from_quantum_job(
+            mock_job,
+            input_two_qubit_gate_counts=[1, 2],
+            transpiled_two_qubit_gate_counts=[3, 4],
+        )
+
+        assert data.provider_job_ids == ["job_with_counts"]
+        assert data.input_two_qubit_gate_counts == [1, 2]
+        assert data.transpiled_two_qubit_gate_counts == [3, 4]
+
 
 class TestBenchmarkDirections:
     def test_no_direction_required_for_float_metric(self):

--- a/tests/unit/benchmarks/test_clops.py
+++ b/tests/unit/benchmarks/test_clops.py
@@ -166,6 +166,9 @@ def test_dispatch_instantiated_calls_device_run():
 
     assert isinstance(result, ClopsData)
     device.run.assert_called_once()
+    assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+    assert len(result.input_two_qubit_gate_counts) == 3
+    assert all(count > 0 for count in result.input_two_qubit_gate_counts)
     # Check circuits were passed
     circuits_arg = device.run.call_args[0][0]
     assert len(circuits_arg) == 3  # num_circuits=3
@@ -203,6 +206,9 @@ def test_dispatch_parameterized_calls_submit_with_pub():
         result = clops.dispatch_handler(device)
 
     assert isinstance(result, ClopsData)
+    assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+    assert len(result.input_two_qubit_gate_counts) == 3
+    assert len(set(result.input_two_qubit_gate_counts)) == 1
     clops._submit_ibm_with_options.assert_called_once()
     kwargs = clops._submit_ibm_with_options.call_args
     pubs = kwargs.kwargs["pubs"]
@@ -247,6 +253,9 @@ def test_dispatch_twirled_calls_submit_with_twirling_opts():
         result = clops.dispatch_handler(device)
 
     assert isinstance(result, ClopsData)
+    assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+    assert len(result.input_two_qubit_gate_counts) == 3
+    assert len(set(result.input_two_qubit_gate_counts)) == 1
     clops._submit_ibm_with_options.assert_called_once()
     kwargs = clops._submit_ibm_with_options.call_args.kwargs
     # Should have a single fixed circuit (no parameters)

--- a/tests/unit/benchmarks/test_eplg.py
+++ b/tests/unit/benchmarks/test_eplg.py
@@ -1,8 +1,13 @@
 """Unit tests for EPLG benchmark."""
 
+import argparse
+from unittest.mock import MagicMock, patch
+
 import rustworkx as rx
 
 from metriq_gym.benchmarks.eplg import (
+    EPLG,
+    EPLGData,
     random_chain_from_graph,
 )
 
@@ -26,3 +31,49 @@ def test_random_chain_from_graph_complete():
 
     assert len(chain) == 5
     assert len(set(chain)) == 5
+
+
+def _make_eplg(decompose_clifford_ops: bool) -> EPLG:
+    params = MagicMock()
+    params.num_qubits_in_chain = 5
+    params.two_qubit_gate = "cx"
+    params.one_qubit_basis_gates = ["sx", "rz"]
+    params.lengths = [4]
+    params.num_samples = 1
+    params.seed = 42
+    params.shots = 100
+    params.decompose_clifford_ops = decompose_clifford_ops
+    return EPLG(argparse.Namespace(), params)
+
+
+def test_dispatch_records_eplg_input_and_transpiled_gate_counts():
+    benchmark = _make_eplg(decompose_clifford_ops=True)
+    device = MagicMock()
+    device.run.return_value.id = "job-eplg"
+    graph = rx.generators.path_graph(10)
+
+    with (
+        patch("metriq_gym.benchmarks.eplg.connectivity_graph_for_gate", return_value=graph),
+        patch("metriq_gym.benchmarks.eplg.connectivity_graph", return_value=graph),
+    ):
+        result = benchmark.dispatch_handler(device)
+
+    assert isinstance(result, EPLGData)
+    assert len(result.input_two_qubit_gate_counts) == len(result.transpiled_two_qubit_gate_counts)
+    assert len(result.input_two_qubit_gate_counts) > 0
+    assert sum(result.transpiled_two_qubit_gate_counts) >= sum(result.input_two_qubit_gate_counts)
+
+
+def test_dispatch_mirrors_eplg_gate_counts_without_decomposition():
+    benchmark = _make_eplg(decompose_clifford_ops=False)
+    device = MagicMock()
+    device.run.return_value.id = "job-eplg"
+    graph = rx.generators.path_graph(10)
+
+    with (
+        patch("metriq_gym.benchmarks.eplg.connectivity_graph_for_gate", return_value=graph),
+        patch("metriq_gym.benchmarks.eplg.connectivity_graph", return_value=graph),
+    ):
+        result = benchmark.dispatch_handler(device)
+
+    assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts

--- a/tests/unit/exporters/test_json_exporter.py
+++ b/tests/unit/exporters/test_json_exporter.py
@@ -11,8 +11,23 @@ def test_json_exporter_serializes_none_uncertainty_to_null(metriq_job, tmp_path)
 
     JsonExporter(metriq_job, result).export(str(outfile))
 
-    with open(outfile) as f:
+    with open(outfile, encoding="utf-8") as f:
         data = json.load(f)
 
     assert data["results"]["expectation_value"]["value"] == 0.42
     assert data["results"]["expectation_value"]["uncertainty"] is None
+
+
+def test_json_exporter_includes_two_qubit_gate_counts(metriq_job, tmp_path):
+    metriq_job.data["input_two_qubit_gate_counts"] = [2, 4]
+    metriq_job.data["transpiled_two_qubit_gate_counts"] = [3, 5]
+    result = WITResult(expectation_value=BenchmarkScore(value=0.42))
+    outfile = tmp_path / "result.json"
+
+    JsonExporter(metriq_job, result).export(str(outfile))
+
+    with open(outfile, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["input_two_qubit_gate_counts"] == [2, 4]
+    assert data["transpiled_two_qubit_gate_counts"] == [3, 5]

--- a/tests/unit/test_registry_imports.py
+++ b/tests/unit/test_registry_imports.py
@@ -1,0 +1,5 @@
+"""Smoke-test benchmark registry imports."""
+
+
+def test_registry_imports():
+    import metriq_gym.registry  # noqa: F401


### PR DESCRIPTION
# Description
Adds two-qubit gate count metadata to benchmark job data and surfaces it throughout the benchmarking workflow.

### Summary of changes
* Added `input_two_qubit_gate_counts` and `transpiled_two_qubit_gate_counts` fields to `BenchmarkData`.
* Added public two-qubit gate-count helper functions in `resource_estimation.py`.
* Populated input and transpiled two-qubit gate counts for EPLG benchmarks.
* Populated mirrored two-qubit gate counts for CLOPS benchmarks, which do not transpile circuits before submission.
* Included two-qubit gate count fields in exported JSON output.
* Added tests covering:
  * Base benchmark data
  * EPLG benchmarks
  * CLOPS benchmarks
  * JSON export functionality
  * Registry imports

No new dependencies are required for this change.

# Issue ticket number and link
Fixes #715

# Type of change
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with:
```bash
uv run ruff check metriq_gym tests/unit tests/e2e
uv run mypy
uv run pytest
uv run pytest -m e2e
```

### Results
* `ruff`: passed
* `mypy`: passed
* `pytest`: 357 passed
* `pytest -m e2e`: 15 passed, 342 deselected

Additionally, verified a local CLOPS dispatch, poll, and export workflow using `local:aer_simulator`.

# Checklist:
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules (or not applicable)

