### PR TITLE
feat(benchmarks): track two-qubit gate counts on benchmark data

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -3,7 +3,7 @@ from typing import Iterable, TYPE_CHECKING, Protocol
 from abc import ABC
 
 from pydantic import BaseModel, computed_field
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 if TYPE_CHECKING:
@@ -27,6 +27,13 @@ class BenchmarkData:
     """Stores intermediate data from pre-processing and dispatching"""
 
     provider_job_ids: list[str]
+    # Two-qubit gate counts, one entry per circuit in dispatch order. Declared
+    # keyword-only so subclasses can keep adding their own required (non-default)
+    # fields without tripping the "non-default argument follows default argument"
+    # dataclass rule. Populated by benchmarks that build circuits; left as None
+    # for benchmarks that have not been wired up yet.
+    input_two_qubit_gate_counts: list[int] | None = field(default=None, kw_only=True)
+    transpiled_two_qubit_gate_counts: list[int] | None = field(default=None, kw_only=True)
 
     @classmethod
     def from_quantum_job(cls, quantum_job, **kwargs):

--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -24,19 +24,12 @@ def flatten_job_ids(job: SupportsId | Iterable[SupportsId]) -> list[str]:
 
 @dataclass
 class BenchmarkData:
-    """Stores intermediate data from pre-processing and dispatching.
-
-    Construction contract: ``provider_job_ids`` is a required positional field,
-    while the gate-count fields are keyword-only. The keyword-only declaration is
-    what lets subclasses keep adding their own required (non-default) positional
-    fields after the base without hitting the dataclass "non-default argument
-    follows default argument" rule. Any direct ``BenchmarkData(...)`` or subclass
-    construction must therefore pass the gate-count values as keyword arguments.
-    """
+    """Stores intermediate data from pre-processing and dispatching"""
 
     provider_job_ids: list[str]
-    # Two-qubit gate counts, one entry per circuit in dispatch order. Populated by
-    # benchmarks that build circuits; left as None for benchmarks not yet wired up.
+    # Two-qubit gate counts per circuit, in dispatch order; None when a benchmark
+    # doesn't set them. Keyword-only so subclasses can still add positional fields
+    # after the base, and so they're passed by keyword when constructing directly.
     input_two_qubit_gate_counts: list[int] | None = field(default=None, kw_only=True)
     transpiled_two_qubit_gate_counts: list[int] | None = field(default=None, kw_only=True)
 

--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -24,14 +24,19 @@ def flatten_job_ids(job: SupportsId | Iterable[SupportsId]) -> list[str]:
 
 @dataclass
 class BenchmarkData:
-    """Stores intermediate data from pre-processing and dispatching"""
+    """Stores intermediate data from pre-processing and dispatching.
+
+    Construction contract: ``provider_job_ids`` is a required positional field,
+    while the gate-count fields are keyword-only. The keyword-only declaration is
+    what lets subclasses keep adding their own required (non-default) positional
+    fields after the base without hitting the dataclass "non-default argument
+    follows default argument" rule. Any direct ``BenchmarkData(...)`` or subclass
+    construction must therefore pass the gate-count values as keyword arguments.
+    """
 
     provider_job_ids: list[str]
-    # Two-qubit gate counts, one entry per circuit in dispatch order. Declared
-    # keyword-only so subclasses can keep adding their own required (non-default)
-    # fields without tripping the "non-default argument follows default argument"
-    # dataclass rule. Populated by benchmarks that build circuits; left as None
-    # for benchmarks that have not been wired up yet.
+    # Two-qubit gate counts, one entry per circuit in dispatch order. Populated by
+    # benchmarks that build circuits; left as None for benchmarks not yet wired up.
     input_two_qubit_gate_counts: list[int] | None = field(default=None, kw_only=True)
     transpiled_two_qubit_gate_counts: list[int] | None = field(default=None, kw_only=True)
 

--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -203,8 +203,10 @@ class BSEQ(Benchmark):
         topology_graph = connectivity_graph(device)
         circuit_sets, coloring = build_bseq_circuits(topology_graph, max_colors)
 
-        # Flatten the per-color circuit sets into submission order. No local
-        # transpilation pass, so transpiled counts mirror the input.
+        # Flatten the per-color circuit sets into one flat list, one entry per
+        # circuit in submission order (the per-color grouping is recoverable from
+        # ``coloring`` if a consumer needs it). No local transpilation pass, so
+        # transpiled counts mirror the input.
         counts = two_qubit_gate_counts(circuit_sets)
 
         quantum_jobs: list[QuantumJob | list[QuantumJob]] = [

--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -50,7 +50,7 @@ from metriq_gym.helpers.graph_helpers import (
     largest_connected_size,
 )
 from metriq_gym.qplatform.device import connectivity_graph
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -205,9 +205,9 @@ class BSEQ(Benchmark):
 
         # Flatten the per-color circuit sets into one flat list, one entry per
         # circuit in submission order (the per-color grouping is recoverable from
-        # ``coloring`` if a consumer needs it). No local transpilation pass, so
+        # coloring if a consumer needs it). No local transpilation pass, so
         # transpiled counts mirror the input.
-        counts = two_qubit_gate_counts(circuit_sets)
+        counts = [count_two_qubit_gates(c) for circ_set in circuit_sets for c in circ_set]
 
         quantum_jobs: list[QuantumJob | list[QuantumJob]] = [
             device.run(circ_set, shots=shots) for circ_set in circuit_sets

--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -50,7 +50,7 @@ from metriq_gym.helpers.graph_helpers import (
     largest_connected_size,
 )
 from metriq_gym.qplatform.device import connectivity_graph
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -203,6 +203,10 @@ class BSEQ(Benchmark):
         topology_graph = connectivity_graph(device)
         circuit_sets, coloring = build_bseq_circuits(topology_graph, max_colors)
 
+        # Flatten the per-color circuit sets into submission order. No local
+        # transpilation pass, so transpiled counts mirror the input.
+        counts = two_qubit_gate_counts(circuit_sets)
+
         quantum_jobs: list[QuantumJob | list[QuantumJob]] = [
             device.run(circ_set, shots=shots) for circ_set in circuit_sets
         ]
@@ -215,6 +219,8 @@ class BSEQ(Benchmark):
 
         return BSEQData(
             provider_job_ids=provider_job_ids,
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
             shots=shots,
             num_qubits=device.num_qubits,
             topology_graph=topology_graph,

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -47,7 +47,7 @@ from metriq_gym.qplatform.device import (
     connectivity_graph_for_gate,
     pruned_connectivity_graph,
 )
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -390,13 +390,22 @@ class Clops(Benchmark):
         circuits = instantiate_circuits(
             template, parameters, self.params.num_circuits, seed=self.params.seed
         )
+        # CLOPS submits circuits directly without a local transpilation pass, so
+        # the transpiled counts mirror the input counts.
+        counts = two_qubit_gate_counts(circuits)
         if isinstance(device, QiskitBackend) and self.params.use_session:
             return ClopsData.from_quantum_job(
                 self._submit_ibm_with_options(
                     device, circuits, shots=self.params.shots, use_session=self.params.use_session
-                )
+                ),
+                input_two_qubit_gate_counts=counts,
+                transpiled_two_qubit_gate_counts=counts,
             )
-        return ClopsData.from_quantum_job(device.run(circuits, shots=self.params.shots))
+        return ClopsData.from_quantum_job(
+            device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
+        )
 
     def _dispatch_parameterized(self, device: QiskitBackend) -> ClopsData:
         """Send a single parameterized circuit with parameter arrays.
@@ -414,8 +423,14 @@ class Clops(Benchmark):
         ]
 
         pub = (template, param_values, self.params.shots)
+        # One template stands in for num_circuits circuits of identical gate
+        # structure; report the count once per logical circuit for consistency
+        # with the instantiated mode. No local transpilation, so input == transpiled.
+        counts = two_qubit_gate_counts(template) * self.params.num_circuits
         return ClopsData.from_quantum_job(
-            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session)
+            self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
         )
 
     def _dispatch_twirled(self, device: QiskitBackend) -> ClopsData:
@@ -433,6 +448,9 @@ class Clops(Benchmark):
             shots_per_randomization=self.params.shots,
             enable_gates=True,
         )
+        # The Sampler twirls one template into num_circuits randomized variants,
+        # each with the same 2Q gate structure. No local transpilation pass.
+        counts = two_qubit_gate_counts(template) * self.params.num_circuits
         return ClopsData.from_quantum_job(
             self._submit_ibm_with_options(
                 device,
@@ -440,7 +458,9 @@ class Clops(Benchmark):
                 shots=self.params.shots * self.params.num_circuits,
                 twirling_options=twirling_opts,
                 use_session=self.params.use_session,
-            )
+            ),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
         )
 
     # ------------------------------------------------------------------

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -47,7 +47,7 @@ from metriq_gym.qplatform.device import (
     connectivity_graph_for_gate,
     pruned_connectivity_graph,
 )
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -392,7 +392,7 @@ class Clops(Benchmark):
         )
         # CLOPS submits circuits directly without a local transpilation pass, so
         # the transpiled counts mirror the input counts.
-        counts = two_qubit_gate_counts(circuits)
+        counts = [count_two_qubit_gates(c) for c in circuits]
         if isinstance(device, QiskitBackend) and self.params.use_session:
             return ClopsData.from_quantum_job(
                 self._submit_ibm_with_options(
@@ -426,7 +426,7 @@ class Clops(Benchmark):
         # One template stands in for num_circuits circuits of identical gate
         # structure; report the count once per logical circuit for consistency
         # with the instantiated mode. No local transpilation, so input == transpiled.
-        counts = two_qubit_gate_counts(template) * self.params.num_circuits
+        counts = [count_two_qubit_gates(template)] * self.params.num_circuits
         return ClopsData.from_quantum_job(
             self._submit_ibm_with_options(device, pubs=[pub], use_session=self.params.use_session),
             input_two_qubit_gate_counts=counts,
@@ -450,7 +450,7 @@ class Clops(Benchmark):
         )
         # The Sampler twirls one template into num_circuits randomized variants,
         # each with the same 2Q gate structure. No local transpilation pass.
-        counts = two_qubit_gate_counts(template) * self.params.num_circuits
+        counts = [count_two_qubit_gates(template)] * self.params.num_circuits
         return ClopsData.from_quantum_job(
             self._submit_ibm_with_options(
                 device,

--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -39,7 +39,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
 )
 from metriq_gym.qplatform.device import connectivity_graph, connectivity_graph_for_gate
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -368,7 +368,7 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
             circuits = lfexp._transpiled_circuits()
         else:
             circuits = input_circuits
-        input_two_qubit_gate_counts = two_qubit_gate_counts(input_circuits)
+        input_two_qubit_gate_counts = [count_two_qubit_gates(c) for c in input_circuits]
 
         return (
             circuits,
@@ -395,7 +395,7 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
         # Counts from the circuits just before submission reflect any
         # transpilation/optimization the dispatch path performed.
-        transpiled_two_qubit_gate_counts = two_qubit_gate_counts(circuits)
+        transpiled_two_qubit_gate_counts = [count_two_qubit_gates(c) for c in circuits]
 
         # Serialize the two_disjoint_layers as nested lists
         serialized_layers = [[list(edge) for edge in layer] for layer in two_disjoint_layers]

--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -39,7 +39,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkResult,
 )
 from metriq_gym.qplatform.device import connectivity_graph, connectivity_graph_for_gate
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -313,12 +313,16 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def _build_circuits(
         self, device: "QuantumDevice"
-    ) -> tuple[list, list[int], list[list[tuple[int, int]]], str, list[str]]:
+    ) -> tuple[list, list[int], list[list[tuple[int, int]]], str, list[str], list[int]]:
         """Build LayerFidelity circuits.
 
         Returns:
             Tuple of (circuits, qubit_chain, two_disjoint_layers,
-                      two_qubit_gate, one_qubit_basis_gates).
+                      two_qubit_gate, one_qubit_basis_gates,
+                      input_two_qubit_gate_counts). ``circuits`` are the
+                      circuits that will be submitted (transpiled when
+                      ``decompose_clifford_ops`` is set); the counts are taken
+                      from the logical pre-transpilation circuits.
         """
         num_qubits_in_chain = self.params.num_qubits_in_chain
         two_qubit_gate = self.params.two_qubit_gate
@@ -356,21 +360,42 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
         )
 
         lfexp.experiment_options.max_circuits = 2 * num_samples * len(lengths)
+        # The logical circuits define the input 2Q counts. When
+        # decompose_clifford_ops is set, the submitted circuits are the
+        # transpiled ones, which can carry a different 2Q count.
+        input_circuits = lfexp.circuits()
         if self.params.decompose_clifford_ops:
             circuits = lfexp._transpiled_circuits()
         else:
-            circuits = lfexp.circuits()
+            circuits = input_circuits
+        input_two_qubit_gate_counts = two_qubit_gate_counts(input_circuits)
 
-        return circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates
+        return (
+            circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+            input_two_qubit_gate_counts,
+        )
 
     def dispatch_handler(self, device: "QuantumDevice") -> EPLGData:
         """Generate circuits, submit to device, return EPLGData."""
-        circuits, qubit_chain, two_disjoint_layers, two_qubit_gate, one_qubit_basis_gates = (
-            self._build_circuits(device)
-        )
+        (
+            circuits,
+            qubit_chain,
+            two_disjoint_layers,
+            two_qubit_gate,
+            one_qubit_basis_gates,
+            input_two_qubit_gate_counts,
+        ) = self._build_circuits(device)
 
         shots = self.params.shots
         quantum_job = device.run(circuits, shots=shots)
+
+        # Counts from the circuits just before submission reflect any
+        # transpilation/optimization the dispatch path performed.
+        transpiled_two_qubit_gate_counts = two_qubit_gate_counts(circuits)
 
         # Serialize the two_disjoint_layers as nested lists
         serialized_layers = [[list(edge) for edge in layer] for layer in two_disjoint_layers]
@@ -386,6 +411,8 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
             seed=self.params.seed,
             two_qubit_gate=two_qubit_gate,
             one_qubit_basis_gates=one_qubit_basis_gates,
+            input_two_qubit_gate_counts=input_two_qubit_gate_counts,
+            transpiled_two_qubit_gate_counts=transpiled_two_qubit_gate_counts,
         )
 
     def poll_handler(
@@ -478,5 +505,5 @@ class EPLG(Benchmark[EPLGData, EPLGResult]):
 
     def estimate_resources_handler(self, device: "QuantumDevice") -> list[CircuitBatch]:
         """Return circuit batches for resource estimation."""
-        circuits, _, _, _, _ = self._build_circuits(device)
+        circuits, *_ = self._build_circuits(device)
         return [CircuitBatch(circuits=circuits, shots=self.params.shots)]

--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -45,7 +45,7 @@ from metriq_gym.benchmarks.benchmark import (
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.qplatform.device import connectivity_graph
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -449,7 +449,7 @@ class LinearRampQAOA(Benchmark):
         )
 
         # No local transpilation pass, so transpiled counts mirror the input.
-        counts = two_qubit_gate_counts(circuits_with_params)
+        counts = [count_two_qubit_gates(c) for c in circuits_with_params]
 
         return LinearRampQAOAData.from_quantum_job(
             quantum_job=device.run(circuits_with_params, shots=self.params.shots),

--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -45,7 +45,7 @@ from metriq_gym.benchmarks.benchmark import (
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.qplatform.device import connectivity_graph
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -448,8 +448,13 @@ class LinearRampQAOA(Benchmark):
             optimal_sol,
         )
 
+        # No local transpilation pass, so transpiled counts mirror the input.
+        counts = two_qubit_gate_counts(circuits_with_params)
+
         return LinearRampQAOAData.from_quantum_job(
             quantum_job=device.run(circuits_with_params, shots=self.params.shots),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
             num_qubits=self.params.num_qubits,
             graph_info=graph_info,
             optimal_sol=optimal_sol,

--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -43,7 +43,7 @@ from metriq_gym.qplatform.device import connectivity_graph
 
 from typing import TYPE_CHECKING
 
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -559,7 +559,7 @@ class MirrorCircuits(Benchmark):
         circuits, expected_bitstrings, actual_width = self._build_circuits(device)
 
         # No local transpilation pass, so transpiled counts mirror the input.
-        counts = two_qubit_gate_counts(circuits)
+        counts = [count_two_qubit_gates(c) for c in circuits]
 
         return MirrorCircuitsData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),

--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -43,7 +43,7 @@ from metriq_gym.qplatform.device import connectivity_graph
 
 from typing import TYPE_CHECKING
 
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -558,8 +558,13 @@ class MirrorCircuits(Benchmark):
     def dispatch_handler(self, device: "QuantumDevice") -> MirrorCircuitsData:
         circuits, expected_bitstrings, actual_width = self._build_circuits(device)
 
+        # No local transpilation pass, so transpiled counts mirror the input.
+        counts = two_qubit_gate_counts(circuits)
+
         return MirrorCircuitsData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
             num_layers=self.params.num_layers,
             two_qubit_gate_prob=self.params.two_qubit_gate_prob,
             two_qubit_gate_name=self.params.two_qubit_gate_name,

--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -32,7 +32,7 @@ from metriq_gym.benchmarks.benchmark import (
 )
 from metriq_gym.constants import JobType
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 from _common import metrics
 
@@ -297,7 +297,7 @@ class QEDCBenchmark(Benchmark):
         circuits, circuit_metrics, circuit_identifiers = self._build_circuits(device)
 
         # No local transpilation pass, so transpiled counts mirror the input.
-        counts = two_qubit_gate_counts(circuits)
+        counts = [count_two_qubit_gates(c) for c in circuits]
 
         return QEDCData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),

--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -32,7 +32,7 @@ from metriq_gym.benchmarks.benchmark import (
 )
 from metriq_gym.constants import JobType
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 from _common import metrics
 
@@ -296,8 +296,13 @@ class QEDCBenchmark(Benchmark):
         # For more information on the parameters, view the schema for this benchmark.
         circuits, circuit_metrics, circuit_identifiers = self._build_circuits(device)
 
+        # No local transpilation pass, so transpiled counts mirror the input.
+        counts = two_qubit_gate_counts(circuits)
+
         return QEDCData.from_quantum_job(
             quantum_job=device.run(circuits, shots=self.params.shots),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
             circuit_metrics=circuit_metrics,
             circuit_identifiers=circuit_identifiers,
         )

--- a/metriq_gym/benchmarks/qml_kernel.py
+++ b/metriq_gym/benchmarks/qml_kernel.py
@@ -30,7 +30,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkScore,
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -118,7 +118,13 @@ class QMLKernel(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> QMLKernelData:
         circuit = self._build_circuits(device)
-        return QMLKernelData.from_quantum_job(device.run(circuit, shots=self.params.shots))
+        # No local transpilation pass, so transpiled counts mirror the input.
+        counts = two_qubit_gate_counts(circuit)
+        return QMLKernelData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
+        )
 
     def poll_handler(
         self,

--- a/metriq_gym/benchmarks/qml_kernel.py
+++ b/metriq_gym/benchmarks/qml_kernel.py
@@ -30,7 +30,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkScore,
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -119,7 +119,7 @@ class QMLKernel(Benchmark):
     def dispatch_handler(self, device: "QuantumDevice") -> QMLKernelData:
         circuit = self._build_circuits(device)
         # No local transpilation pass, so transpiled counts mirror the input.
-        counts = two_qubit_gate_counts(circuit)
+        counts = [count_two_qubit_gates(circuit)]
         return QMLKernelData.from_quantum_job(
             device.run(circuit, shots=self.params.shots),
             input_two_qubit_gate_counts=counts,

--- a/metriq_gym/benchmarks/wit.py
+++ b/metriq_gym/benchmarks/wit.py
@@ -34,7 +34,7 @@ from metriq_gym.helpers.statistics import (
     binary_expectation_stddev,
     binary_expectation_value,
 )
-from metriq_gym.resource_estimation import CircuitBatch
+from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -260,7 +260,13 @@ class WIT(Benchmark):
 
     def dispatch_handler(self, device: "QuantumDevice") -> WITData:
         circuit = self._build_circuits(device)
-        return WITData.from_quantum_job(device.run(circuit, shots=self.params.shots))
+        # No local transpilation pass, so transpiled counts mirror the input.
+        counts = two_qubit_gate_counts(circuit)
+        return WITData.from_quantum_job(
+            device.run(circuit, shots=self.params.shots),
+            input_two_qubit_gate_counts=counts,
+            transpiled_two_qubit_gate_counts=counts,
+        )
 
     def poll_handler(
         self,

--- a/metriq_gym/benchmarks/wit.py
+++ b/metriq_gym/benchmarks/wit.py
@@ -34,7 +34,7 @@ from metriq_gym.helpers.statistics import (
     binary_expectation_stddev,
     binary_expectation_value,
 )
-from metriq_gym.resource_estimation import CircuitBatch, two_qubit_gate_counts
+from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
     from qbraid import GateModelResultData, QuantumDevice, QuantumJob
@@ -261,7 +261,7 @@ class WIT(Benchmark):
     def dispatch_handler(self, device: "QuantumDevice") -> WITData:
         circuit = self._build_circuits(device)
         # No local transpilation pass, so transpiled counts mirror the input.
-        counts = two_qubit_gate_counts(circuit)
+        counts = [count_two_qubit_gates(circuit)]
         return WITData.from_quantum_job(
             device.run(circuit, shots=self.params.shots),
             input_two_qubit_gate_counts=counts,

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -84,6 +84,22 @@ class BaseExporter(ABC):
 
         record["platform"] = platform_info
 
+        # Surface per-circuit two-qubit gate counts collected at dispatch time.
+        # These live on the BenchmarkData (stored as the job's ``data`` dict) and
+        # are emitted additively so existing fields are unaffected.
+        job_data = getattr(self.metriq_gym_job, "data", None)
+        if isinstance(job_data, dict):
+            circuit_metadata = {
+                key: job_data[key]
+                for key in (
+                    "input_two_qubit_gate_counts",
+                    "transpiled_two_qubit_gate_counts",
+                )
+                if job_data.get(key) is not None
+            }
+            if circuit_metadata:
+                record["circuit_metadata"] = circuit_metadata
+
         return record
 
     @abstractmethod

--- a/metriq_gym/resource_estimation.py
+++ b/metriq_gym/resource_estimation.py
@@ -78,38 +78,16 @@ def _count_gates(circuit: QuantumCircuit) -> GateCounts:
 
 
 def count_two_qubit_gates(circuit: QuantumCircuit) -> int:
-    """Return the number of two-qubit *gates* in a circuit.
+    """Number of two-qubit gates in a circuit.
 
-    Only genuine two-qubit gate operations are counted. ``barrier`` (which can
-    span two qubits but is not a gate), ``measure``, and ``reset`` are skipped by
-    name so the count is not inflated. This is the public helper benchmarks use to
-    record per-circuit 2Q gate counts.
+    Barriers, measurements, and resets are skipped by name so they don't inflate
+    the count (a barrier can span two qubits but isn't a gate).
     """
-    count = 0
-    for inst in circuit.data:
-        if inst.operation.name in ("barrier", "measure", "reset"):
-            continue
-        if len(inst.qubits) == 2:
-            count += 1
-    return count
-
-
-def two_qubit_gate_counts(
-    circuits: "QuantumCircuit | Iterable",
-) -> list[int]:
-    """Return per-circuit two-qubit gate counts in iteration order.
-
-    Accepts a single circuit, a flat iterable of circuits, or a nested
-    iterable of circuits (e.g. BSEQ's list-of-circuit-sets). The result is a
-    flat ``list[int]`` with one entry per circuit, flattened in traversal
-    order so it lines up with the order circuits are submitted to the device.
-    """
-    if isinstance(circuits, QuantumCircuit):
-        return [count_two_qubit_gates(circuits)]
-    counts: list[int] = []
-    for item in circuits:
-        counts.extend(two_qubit_gate_counts(item))
-    return counts
+    return sum(
+        1
+        for inst in circuit.data
+        if inst.operation.name not in ("barrier", "measure", "reset") and len(inst.qubits) == 2
+    )
 
 
 HQCFunction = Callable[[GateCounts, int, int], float]

--- a/metriq_gym/resource_estimation.py
+++ b/metriq_gym/resource_estimation.py
@@ -80,17 +80,14 @@ def _count_gates(circuit: QuantumCircuit) -> GateCounts:
 def count_two_qubit_gates(circuit: QuantumCircuit) -> int:
     """Return the number of two-qubit *gates* in a circuit.
 
-    Only genuine two-qubit gate operations are counted. Non-gate instructions
-    are skipped: directives such as ``barrier`` (which can span two qubits but
-    are not gates), as well as ``measure`` and ``reset``. This is the public
-    helper benchmarks use to record per-circuit 2Q gate counts.
+    Only genuine two-qubit gate operations are counted. ``barrier`` (which can
+    span two qubits but is not a gate), ``measure``, and ``reset`` are skipped by
+    name so the count is not inflated. This is the public helper benchmarks use to
+    record per-circuit 2Q gate counts.
     """
     count = 0
     for inst in circuit.data:
-        operation = inst.operation
-        if getattr(operation, "_directive", False):
-            continue
-        if operation.name in ("measure", "reset"):
+        if inst.operation.name in ("barrier", "measure", "reset"):
             continue
         if len(inst.qubits) == 2:
             count += 1

--- a/metriq_gym/resource_estimation.py
+++ b/metriq_gym/resource_estimation.py
@@ -77,6 +77,44 @@ def _count_gates(circuit: QuantumCircuit) -> GateCounts:
     return counts
 
 
+def count_two_qubit_gates(circuit: QuantumCircuit) -> int:
+    """Return the number of two-qubit *gates* in a circuit.
+
+    Only genuine two-qubit gate operations are counted. Non-gate instructions
+    are skipped: directives such as ``barrier`` (which can span two qubits but
+    are not gates), as well as ``measure`` and ``reset``. This is the public
+    helper benchmarks use to record per-circuit 2Q gate counts.
+    """
+    count = 0
+    for inst in circuit.data:
+        operation = inst.operation
+        if getattr(operation, "_directive", False):
+            continue
+        if operation.name in ("measure", "reset"):
+            continue
+        if len(inst.qubits) == 2:
+            count += 1
+    return count
+
+
+def two_qubit_gate_counts(
+    circuits: "QuantumCircuit | Iterable",
+) -> list[int]:
+    """Return per-circuit two-qubit gate counts in iteration order.
+
+    Accepts a single circuit, a flat iterable of circuits, or a nested
+    iterable of circuits (e.g. BSEQ's list-of-circuit-sets). The result is a
+    flat ``list[int]`` with one entry per circuit, flattened in traversal
+    order so it lines up with the order circuits are submitted to the device.
+    """
+    if isinstance(circuits, QuantumCircuit):
+        return [count_two_qubit_gates(circuits)]
+    counts: list[int] = []
+    for item in circuits:
+        counts.extend(two_qubit_gate_counts(item))
+    return counts
+
+
 HQCFunction = Callable[[GateCounts, int, int], float]
 
 

--- a/tests/unit/benchmarks/test_gate_counts.py
+++ b/tests/unit/benchmarks/test_gate_counts.py
@@ -1,0 +1,239 @@
+"""Tests for two-qubit gate-count tracking on benchmark data.
+
+Covers:
+  - the public counting helpers in ``resource_estimation``,
+  - the keyword-only base-class fields (and that subclasses with required
+    fields still construct),
+  - a transpiling benchmark (EPLG) where input and transpiled counts differ,
+  - a non-transpiling benchmark (CLOPS) where transpiled mirrors input,
+  - the exporter surfacing the counts in the exported record.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import rustworkx as rx
+from qbraid import QuantumJob
+from qiskit import QuantumCircuit
+
+from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult
+from metriq_gym.benchmarks.clops import Clops, ClopsData
+from metriq_gym.benchmarks.eplg import EPLG, EPLGData
+from metriq_gym.constants import JobType
+from metriq_gym.exporters.dict_exporter import DictExporter
+from metriq_gym.job_manager import MetriqGymJob
+from metriq_gym.resource_estimation import count_two_qubit_gates, two_qubit_gate_counts
+
+
+def _circuit_with_2q_gates(n: int) -> QuantumCircuit:
+    """A 2-qubit circuit carrying exactly ``n`` two-qubit gates."""
+    qc = QuantumCircuit(2)
+    for _ in range(n):
+        qc.cx(0, 1)
+    return qc
+
+
+class TestCountingHelpers:
+    def test_counts_only_two_qubit_gates(self):
+        qc = QuantumCircuit(3)
+        qc.h(0)  # 1q
+        qc.cx(0, 1)  # 2q
+        qc.cz(1, 2)  # 2q
+        qc.ccx(0, 1, 2)  # 3q, not counted
+        assert count_two_qubit_gates(qc) == 2
+
+    def test_excludes_barriers_and_measurements(self):
+        # measure_all() inserts a (2-wide) barrier plus measurements; neither is
+        # a gate and must not inflate the two-qubit count.
+        qc = _circuit_with_2q_gates(2)
+        qc.measure_all()
+        assert count_two_qubit_gates(qc) == 2
+
+    def test_two_qubit_gate_counts_single_circuit(self):
+        assert two_qubit_gate_counts(_circuit_with_2q_gates(3)) == [3]
+
+    def test_two_qubit_gate_counts_flat_list(self):
+        circuits = [_circuit_with_2q_gates(1), _circuit_with_2q_gates(2)]
+        assert two_qubit_gate_counts(circuits) == [1, 2]
+
+    def test_two_qubit_gate_counts_nested_in_order(self):
+        # e.g. BSEQ's list-of-circuit-sets is flattened in submission order.
+        nested = [
+            [_circuit_with_2q_gates(1)],
+            [_circuit_with_2q_gates(2), _circuit_with_2q_gates(3)],
+        ]
+        assert two_qubit_gate_counts(nested) == [1, 2, 3]
+
+
+class TestBenchmarkDataFields:
+    def test_defaults_are_none(self):
+        data = BenchmarkData(provider_job_ids=["j"])
+        assert data.input_two_qubit_gate_counts is None
+        assert data.transpiled_two_qubit_gate_counts is None
+
+    def test_keyword_only_does_not_break_subclass_ordering(self):
+        # Regression guard: subclasses add their own *required* fields after the
+        # base. The new fields are keyword-only precisely so this still works.
+        @dataclass
+        class CustomData(BenchmarkData):
+            required_field: int
+
+        data = CustomData(
+            provider_job_ids=["j"],
+            required_field=7,
+            input_two_qubit_gate_counts=[1, 2],
+            transpiled_two_qubit_gate_counts=[3, 4],
+        )
+        assert data.required_field == 7
+        assert data.input_two_qubit_gate_counts == [1, 2]
+        assert data.transpiled_two_qubit_gate_counts == [3, 4]
+
+
+class TestEPLGGateCounts:
+    """EPLG genuinely transpiles, so input and transpiled counts can differ."""
+
+    @patch("metriq_gym.benchmarks.eplg.LayerFidelity")
+    @patch("metriq_gym.benchmarks.eplg.random_chain_from_graph", return_value=[0, 1])
+    @patch("metriq_gym.benchmarks.eplg.connectivity_graph_for_gate")
+    def test_input_and_transpiled_counts_differ(
+        self, mock_conn_for_gate, _mock_chain, mock_layer_fidelity
+    ):
+        graph = rx.PyGraph()
+        graph.add_nodes_from([0, 1])
+        graph.add_edge(0, 1, None)
+        mock_conn_for_gate.return_value = graph
+
+        # Logical circuit has 1 two-qubit gate; the transpiled one has 3.
+        logical = [_circuit_with_2q_gates(1)]
+        transpiled = [_circuit_with_2q_gates(3)]
+        lfexp = MagicMock()
+        lfexp.circuits.return_value = logical
+        lfexp._transpiled_circuits.return_value = transpiled
+        mock_layer_fidelity.return_value = lfexp
+
+        params = MagicMock()
+        params.num_qubits_in_chain = 2
+        params.two_qubit_gate = "cx"
+        params.one_qubit_basis_gates = ["sx", "rz"]
+        params.lengths = [1]
+        params.num_samples = 1
+        params.seed = 0
+        params.shots = 100
+        params.decompose_clifford_ops = True  # submit the transpiled circuits
+
+        mock_job = MagicMock(spec=QuantumJob)
+        mock_job.id = "eplg_job"
+        device = MagicMock()
+        device.run.return_value = mock_job
+
+        result = EPLG(MagicMock(), params).dispatch_handler(device)
+
+        assert isinstance(result, EPLGData)
+        assert result.input_two_qubit_gate_counts == [1]
+        assert result.transpiled_two_qubit_gate_counts == [3]
+
+    @patch("metriq_gym.benchmarks.eplg.LayerFidelity")
+    @patch("metriq_gym.benchmarks.eplg.random_chain_from_graph", return_value=[0, 1])
+    @patch("metriq_gym.benchmarks.eplg.connectivity_graph_for_gate")
+    def test_counts_match_when_not_decomposing(
+        self, mock_conn_for_gate, _mock_chain, mock_layer_fidelity
+    ):
+        graph = rx.PyGraph()
+        graph.add_nodes_from([0, 1])
+        graph.add_edge(0, 1, None)
+        mock_conn_for_gate.return_value = graph
+
+        logical = [_circuit_with_2q_gates(2)]
+        lfexp = MagicMock()
+        lfexp.circuits.return_value = logical
+        lfexp._transpiled_circuits.return_value = [_circuit_with_2q_gates(9)]
+        mock_layer_fidelity.return_value = lfexp
+
+        params = MagicMock()
+        params.num_qubits_in_chain = 2
+        params.two_qubit_gate = "cx"
+        params.one_qubit_basis_gates = ["sx", "rz"]
+        params.lengths = [1]
+        params.num_samples = 1
+        params.seed = 0
+        params.shots = 100
+        params.decompose_clifford_ops = False  # submit the logical circuits
+
+        mock_job = MagicMock(spec=QuantumJob)
+        mock_job.id = "eplg_job"
+        device = MagicMock()
+        device.run.return_value = mock_job
+
+        result = EPLG(MagicMock(), params).dispatch_handler(device)
+
+        # Without local transpilation the submitted circuits are the logical ones.
+        assert result.input_two_qubit_gate_counts == [2]
+        assert result.transpiled_two_qubit_gate_counts == [2]
+
+
+class TestClopsGateCounts:
+    """CLOPS submits circuits directly, so transpiled mirrors input."""
+
+    @patch("metriq_gym.benchmarks.clops.instantiate_circuits")
+    @patch.object(Clops, "_build_template")
+    def test_transpiled_mirrors_input(self, mock_build_template, mock_instantiate):
+        mock_build_template.return_value = (MagicMock(), [])
+        circuits = [_circuit_with_2q_gates(4), _circuit_with_2q_gates(4)]
+        mock_instantiate.return_value = circuits
+
+        params = MagicMock()
+        params.mode = "instantiated"
+        params.num_circuits = 2
+        params.shots = 100
+        params.seed = 0
+        params.use_session = False
+
+        mock_job = MagicMock(spec=QuantumJob)
+        mock_job.id = "clops_job"
+        device = MagicMock()
+        device.run.return_value = mock_job
+
+        result = Clops(MagicMock(), params).dispatch_handler(device)
+
+        assert isinstance(result, ClopsData)
+        assert result.input_two_qubit_gate_counts == [4, 4]
+        assert result.transpiled_two_qubit_gate_counts == [4, 4]
+        assert result.input_two_qubit_gate_counts == result.transpiled_two_qubit_gate_counts
+
+
+class _DummyResult(BenchmarkResult):
+    metric: float
+
+
+class TestExporterSurfacesCounts:
+    def _job(self, data: dict) -> MetriqGymJob:
+        return MetriqGymJob(
+            id="job",
+            job_type=JobType.CLOPS,
+            params={"shots": 10},
+            data=data,
+            provider_name="provider",
+            device_name="device",
+            dispatch_time=datetime.now(),
+        )
+
+    def test_counts_present_in_export(self):
+        job = self._job(
+            {
+                "provider_job_ids": ["q"],
+                "input_two_qubit_gate_counts": [4, 4],
+                "transpiled_two_qubit_gate_counts": [4, 4],
+            }
+        )
+        record = DictExporter(job, _DummyResult(metric=1.0)).export()
+        assert record["circuit_metadata"] == {
+            "input_two_qubit_gate_counts": [4, 4],
+            "transpiled_two_qubit_gate_counts": [4, 4],
+        }
+
+    def test_no_circuit_metadata_when_absent(self):
+        # Backward compatibility: records without the counts emit no new block.
+        job = self._job({"provider_job_ids": ["q"]})
+        record = DictExporter(job, _DummyResult(metric=1.0)).export()
+        assert "circuit_metadata" not in record

--- a/tests/unit/benchmarks/test_gate_counts.py
+++ b/tests/unit/benchmarks/test_gate_counts.py
@@ -23,7 +23,7 @@ from metriq_gym.benchmarks.eplg import EPLG, EPLGData
 from metriq_gym.constants import JobType
 from metriq_gym.exporters.dict_exporter import DictExporter
 from metriq_gym.job_manager import MetriqGymJob
-from metriq_gym.resource_estimation import count_two_qubit_gates, two_qubit_gate_counts
+from metriq_gym.resource_estimation import count_two_qubit_gates
 
 
 def _circuit_with_2q_gates(n: int) -> QuantumCircuit:
@@ -49,21 +49,6 @@ class TestCountingHelpers:
         qc = _circuit_with_2q_gates(2)
         qc.measure_all()
         assert count_two_qubit_gates(qc) == 2
-
-    def test_two_qubit_gate_counts_single_circuit(self):
-        assert two_qubit_gate_counts(_circuit_with_2q_gates(3)) == [3]
-
-    def test_two_qubit_gate_counts_flat_list(self):
-        circuits = [_circuit_with_2q_gates(1), _circuit_with_2q_gates(2)]
-        assert two_qubit_gate_counts(circuits) == [1, 2]
-
-    def test_two_qubit_gate_counts_nested_in_order(self):
-        # e.g. BSEQ's list-of-circuit-sets is flattened in submission order.
-        nested = [
-            [_circuit_with_2q_gates(1)],
-            [_circuit_with_2q_gates(2), _circuit_with_2q_gates(3)],
-        ]
-        assert two_qubit_gate_counts(nested) == [1, 2, 3]
 
 
 class TestBenchmarkDataFields:


### PR DESCRIPTION
Fixes #715
# Description

Adds per-circuit two-qubit gate-count tracking to benchmark data. Two new fields are added to the base `BenchmarkData` dataclass so every benchmark inherits them:

- `input_two_qubit_gate_counts: list[int] | None` — 2Q gate count for each circuit the benchmark builds, in dispatch order.
- `transpiled_two_qubit_gate_counts: list[int] | None` — 2Q gate count for each circuit as submitted, after any transpilation/optimization the dispatch path performs.

**Design:** the base class keeps `@dataclass` and declares both fields as **keyword-only** (`field(default=None, kw_only=True)`). This lets the new fields carry defaults without colliding with the required (non-default) fields that
subclasses add after the base — avoiding the "non-default argument follows default argument" error — so **no subclass needs to be modified**, and `from_quantum_job` / `flatten_job_ids` are left unchanged.

Counting is done by a single public helper in `resource_estimation.py`: `count_two_qubit_gates(circuit)` and `two_qubit_gate_counts(circuits)` (accepts a single circuit, a flat list, or a nested list — e.g. BSEQ's circuit sets — and flattens in submission order). It counts only genuine two-qubit gate operations, skipping directives (`barrier`), `measure`, and `reset` so non-gate instructions don't inflate the count. The existing `_count_gates` is intentionally left untouched to avoid changing current resource-estimate output.

Per-benchmark wiring:
- **EPLG** transpiles, so input is taken from `lfexp.circuits()` and transpiled from the circuits just before submission (they differ when `decompose_clifford_ops` is set).
- **CLOPS, BSEQ, mirror circuits, QML kernel, WIT, LR-QAOA, QEDC** (QFT / BV / hidden shift / phase estimation) submit circuits directly with no local transpilation pass, so `transpiled` mirrors `input`. All three CLOPS dispatch modes (instantiated / parameterized / twirled) are covered.

The counts are surfaced in the exported record via a new additive `circuit_metadata` block in `base_exporter.as_dict()`, emitted only when present — no breaking changes to existing fields.

**Dependencies:** none. No new packages required.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added `tests/unit/benchmarks/test_gate_counts.py` covering:

- counting-helper correctness, including barrier/measure/reset exclusion and nested-list ordering;
- base-class fields default to `None`, and a subclass with a required field still constructs (regression guard for dataclass field ordering);
- **EPLG** (transpiling benchmark): input vs transpiled counts differ, asserted against concrete expected values;
- **CLOPS** (non-transpiling benchmark): transpiled mirrors input;
- exporter surfaces `circuit_metadata`, and omits it for older records that lack
  the fields.

Reproduce:

```bash
# new tests
pytest tests/unit/benchmarks/test_gate_counts.py -q

# regression check on the surrounding suite
pytest tests/unit/benchmarks/test_benchmark.py tests/unit/benchmarks/test_mirror_circuits.py -q
```
All new tests pass and the existing suite shows no regressions. `ruff format` , `ruff check` , and `mypy` are clean on the changed files.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)

### Notes for reviewers

- The two new fields are **keyword-only** by design, so every existing subclass stays untouched (avoids the dataclass field-ordering problem). All call sites pass them as keyword arguments.
- `count_two_qubit_gates` excludes `barrier`/`measure`/`reset`. I left the existing `_count_gates` as-is to avoid changing resource-estimate output; happy to unify if you'd prefer.
- Only EPLG transpiles locally, so it's the one benchmark where `input` and `transpiled` counts differ. The others submit directly, so `transpiled` mirrors `input` (per the issue's CLOPS guidance).
- `qat_ole` isn't in the issue's list, so it inherits the `None` defaults — easy to wire up if you'd like.

### AI disclosure

I used Claude as an assistant while working on this PR (exploring the codebase, sanity-checking the design against the prior attempts, and drafting tests). I reviewed every change myself and ran ruff, mypy, and pytest locally before submitting.