### PR TITLE
Fix failures from LR-QAOA workflows on Ionq@AWS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ MGYM_LOCAL_SIMULATOR_CACHE_DIR="<MGYM_LOCAL_SIMULATOR_CACHE_DIR>"
 METRIQ_CLIENT_API_KEY="<METRIQ_CLIENT_API_KEY>"
 
 # AWS
+# Optional default region for AWS operations. A Braket device ARN takes precedence.
+# AWS_REGION="<AWS_REGION>"
 # Obtained at: https://aws.amazon.com/braket/
 AWS_ACCESS_KEY_ID="<AWS_ACCESS_KEY_ID>"
 AWS_SECRET_ACCESS_KEY="<AWS_SECRET_ACCESS_KEY>"

--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -44,7 +44,7 @@ from metriq_gym.benchmarks.benchmark import (
     BenchmarkScore,
 )
 from metriq_gym.helpers.task_helpers import flatten_counts
-from metriq_gym.qplatform.device import connectivity_graph
+from metriq_gym.qplatform.device import connectivity_graph, validate_qubit_capacity
 from metriq_gym.resource_estimation import CircuitBatch, count_two_qubit_gates
 
 if TYPE_CHECKING:
@@ -373,6 +373,8 @@ class LinearRampQAOA(Benchmark):
             Tuple of (circuits_with_params, graph_info, optimal_sol, circuit_encoding).
         """
         num_qubits = self.params.num_qubits
+        validate_qubit_capacity(device, num_qubits)
+
         graph_type = self.params.graph_type
         qaoa_layers = self.params.qaoa_layers
         trials = self.params.trials

--- a/metriq_gym/exceptions.py
+++ b/metriq_gym/exceptions.py
@@ -1,2 +1,6 @@
 class QBraidSetupError(Exception):
     pass
+
+
+class DeviceCapacityError(ValueError):
+    """Raised when a benchmark requests more qubits than a device provides."""

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -10,6 +10,7 @@ from qiskit.transpiler import CouplingMap
 from pytket.architecture import FullyConnected
 
 from metriq_gym.local.device import LocalAerDevice
+from metriq_gym.exceptions import DeviceCapacityError
 from qbraid.runtime.origin import OriginDevice
 from metriq_gym.quantinuum.device import QuantinuumDevice
 
@@ -48,6 +49,19 @@ def _complete_graph_for_device(device: QuantumDevice, device_type: str) -> rx.Py
             f"{device_type} device {device.id} does not report a qubit count for connectivity graph"
         )
     return rx.generators.complete_graph(num_qubits)
+
+
+def validate_qubit_capacity(device: QuantumDevice, required_qubits: int) -> None:
+    """Reject workloads that exceed a device's reported qubit capacity."""
+    available_qubits = device.num_qubits
+    if not isinstance(available_qubits, int):
+        return
+
+    if required_qubits > available_qubits:
+        raise DeviceCapacityError(
+            f"Requested {required_qubits} qubits, but device {device.id} supports "
+            f"only {available_qubits}."
+        )
 
 
 def _braket_metadata_is_fully_connected(device: BraketDevice) -> bool:

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -53,7 +53,11 @@ def _complete_graph_for_device(device: QuantumDevice, device_type: str) -> rx.Py
 
 def validate_qubit_capacity(device: QuantumDevice, required_qubits: int) -> None:
     """Reject workloads that exceed a device's reported qubit capacity."""
-    available_qubits = device.num_qubits
+    try:
+        available_qubits = device.num_qubits
+    except AttributeError:
+        return
+
     if not isinstance(available_qubits, int):
         return
 

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -41,6 +41,60 @@ def coupling_map_to_graph(coupling_map: CouplingMap) -> rx.PyGraph:
     return coupling_map.graph.to_undirected(multigraph=False)
 
 
+def _complete_graph_for_device(device: QuantumDevice, device_type: str) -> rx.PyGraph:
+    num_qubits = device.num_qubits
+    if not isinstance(num_qubits, int):
+        raise NotImplementedError(
+            f"{device_type} device {device.id} does not report a qubit count for connectivity graph"
+        )
+    return rx.generators.complete_graph(num_qubits)
+
+
+def _braket_metadata_is_fully_connected(device: BraketDevice) -> bool:
+    try:
+        connectivity = device._device.properties.paradigm.connectivity
+    except AttributeError:
+        return False
+    return connectivity.fullyConnected is True
+
+
+def _is_braket_all_to_all_device(device: BraketDevice) -> bool:
+    provider_name = (device._provider_name or "").lower()
+
+    if device.simulator is True or provider_name == "amazon braket":
+        return True
+
+    if provider_name == "ionq" or "/ionq/" in device.id.lower():
+        return True
+
+    return _braket_metadata_is_fully_connected(device)
+
+
+def _braket_topology_graph(device: BraketDevice) -> nx.Graph | None:
+    try:
+        return device._device.topology_graph
+    except AttributeError:
+        return None
+
+
+@singledispatch
+def prepare_device_for_dispatch(device: QuantumDevice) -> None:
+    """Apply provider-specific runtime workarounds before submitting benchmarks."""
+
+
+@prepare_device_for_dispatch.register
+def _(device: BraketDevice) -> None:
+    if device._device.properties is not None:
+        return
+
+    logger.warning(
+        "Amazon Braket capabilities for device %s could not be parsed; "
+        "disabling qBraid runtime validation for dispatch.",
+        device.id,
+    )
+    device.set_options(validate=False)
+
+
 @singledispatch
 def connectivity_graph(device: QuantumDevice) -> rx.PyGraph:
     raise NotImplementedError(
@@ -55,10 +109,14 @@ def _(device: QiskitBackend) -> rx.PyGraph:
 
 @connectivity_graph.register
 def _(device: BraketDevice) -> rx.PyGraph:
-    if device._provider_name == "Amazon Braket":
-        device_topology = nx.complete_graph(device.num_qubits)
-    else:
-        device_topology = device._device.topology_graph.to_undirected()
+    device_topology = _braket_topology_graph(device)
+
+    if device_topology is None:
+        if _is_braket_all_to_all_device(device):
+            return _complete_graph_for_device(device, "Braket")
+        raise NotImplementedError(f"Connectivity graph not available for Braket device {device.id}")
+
+    device_topology = device_topology.to_undirected()
 
     return cast(
         rx.PyGraph,
@@ -109,7 +167,7 @@ def _(device: OriginDevice) -> rx.PyGraph:
             "Origin device does not report a qubit count for connectivity graph"
         )
 
-    if getattr(device.profile, "simulator", False):
+    if device.profile.simulator:
         return rx.generators.complete_graph(num_qubits)
 
     try:
@@ -186,18 +244,20 @@ def normalized_metadata(device: QuantumDevice) -> dict:
     """
     meta: dict = {}
     try:
-        simulator = getattr(getattr(device, "profile", object()), "simulator", None)
+        simulator = device.profile.simulator
+    except AttributeError:
+        pass
+    else:
         if isinstance(simulator, bool):
             meta["simulator"] = simulator
-    except Exception:
-        pass
 
     try:
-        n = getattr(device, "num_qubits", None)
-        if isinstance(n, int):
-            meta["num_qubits"] = n
-    except Exception:
+        num_qubits = device.num_qubits
+    except AttributeError:
         pass
+    else:
+        if isinstance(num_qubits, int):
+            meta["num_qubits"] = num_qubits
 
     try:
         ver = version(device)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -145,6 +145,9 @@ def setup_device(provider_name: str, device_name: str):
         )
         logger.error(f"Devices available: {devices}")
         raise QBraidSetupError("Device not found")
+    from metriq_gym.qplatform.device import prepare_device_for_dispatch
+
+    prepare_device_for_dispatch(device)
     return device
 
 

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -24,7 +24,7 @@ from metriq_gym.resource_estimation import (
     quantinuum_hqc_formula,
 )
 from metriq_gym.suite_parser import parse_suite_file
-from metriq_gym.exceptions import QBraidSetupError
+from metriq_gym.exceptions import DeviceCapacityError, QBraidSetupError
 from metriq_gym.upload_paths import default_upload_dir, job_filename, suite_filename
 
 
@@ -103,6 +103,35 @@ COMMON_SUITE_METADATA = {
 }
 
 
+def _braket_region_from_arn(device_name: str) -> str | None:
+    """Return the region encoded in an Amazon Braket device ARN."""
+    arn_fields = device_name.split(":", 5)
+    if len(arn_fields) != 6:
+        return None
+
+    arn_prefix, _partition, service, region, _account, _resource = arn_fields
+    if arn_prefix != "arn" or service != "braket":
+        return None
+    return region or None
+
+
+def _get_device_with_arn_region(provider, device_name: str):
+    """Initialize Braket using its ARN region without changing process configuration."""
+    region = _braket_region_from_arn(device_name)
+    if region is None:
+        return provider.get_device(device_name)
+
+    previous_region = os.environ.get("AWS_REGION")
+    os.environ["AWS_REGION"] = region
+    try:
+        return provider.get_device(device_name)
+    finally:
+        if previous_region is None:
+            os.environ.pop("AWS_REGION", None)
+        else:
+            os.environ["AWS_REGION"] = previous_region
+
+
 def setup_device(provider_name: str, device_name: str):
     """
     Setup a QBraid device with id device_name from specified provider.
@@ -137,7 +166,7 @@ def setup_device(provider_name: str, device_name: str):
         raise QBraidSetupError("Device not found")
 
     try:
-        device = provider.get_device(device_name)
+        device = _get_device_with_arn_region(provider, device_name)
     except QbraidError:
         devices = ", ".join([device.id for device in provider.get_devices()])
         logger.error(
@@ -154,6 +183,17 @@ def setup_device(provider_name: str, device_name: str):
 def setup_benchmark(args, params, job_type: JobType) -> "Benchmark":
     reg = _lazy_registry()
     return reg.BENCHMARK_HANDLERS[job_type](args, params)
+
+
+def validate_benchmark_device_capacity(params, device) -> None:
+    """Validate explicit benchmark width before constructing its handler."""
+    requested_qubits = params.model_dump(exclude_none=True).get("num_qubits")
+    if not isinstance(requested_qubits, int):
+        return
+
+    from metriq_gym.qplatform.device import validate_qubit_capacity
+
+    validate_qubit_capacity(device, requested_qubits)
 
 
 def setup_job_data_class(job_type: JobType) -> type["BenchmarkData"]:
@@ -200,6 +240,12 @@ def dispatch_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         return
 
     job_type = JobType(params.benchmark_name)
+
+    try:
+        validate_benchmark_device_capacity(params, device)
+    except DeviceCapacityError as exc:
+        print(f"✗ {params.benchmark_name}: {exc}")
+        return
 
     print(f"Dispatching {params.benchmark_name}...")
 
@@ -280,6 +326,8 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
                 continue
 
             job_type = JobType(params.benchmark_name)
+
+            validate_benchmark_device_capacity(params, device)
 
             print(
                 f"Dispatching {benchmark_entry.name} ({params.benchmark_name}) from {suite.name}..."
@@ -875,6 +923,14 @@ def estimate_job(args: argparse.Namespace, _job_manager: JobManager | None = Non
         return
 
     job_type = JobType(params.benchmark_name)
+
+    if device is not None:
+        try:
+            validate_benchmark_device_capacity(params, device)
+        except DeviceCapacityError as exc:
+            print(f"✗ {job_type.value}: {exc}")
+            return
+
     benchmark: Benchmark = setup_benchmark(args, params, job_type)
 
     try:

--- a/metriq_gym/suites/lr_qaoa_scale.json
+++ b/metriq_gym/suites/lr_qaoa_scale.json
@@ -1,0 +1,70 @@
+{
+  "name": "lr_qaoa_1d_scale_suite",
+  "description": "Verified Linear Ramp QAOA 1D benchmarks at different scales.",
+  "benchmarks": [
+    {
+        "name": "LR_QAOA_1D_10",
+        "config": {
+            "benchmark_name": "Linear Ramp QAOA",
+            "confidence_level": 0.999,
+            "delta_beta": 0.3,
+            "delta_gamma": 0.6,
+            "graph_type": "1D",
+            "num_qubits": 10,
+            "num_random_trials": 25,
+            "qaoa_layers": [10],
+            "seed": 123,
+            "shots": 1000,
+            "trials": 10
+        }
+    },
+    {
+        "name": "LR_QAOA_1D_20",
+        "config": {
+            "benchmark_name": "Linear Ramp QAOA",
+            "confidence_level": 0.999,
+            "delta_beta": 0.3,
+            "delta_gamma": 0.6,
+            "graph_type": "1D",
+            "num_qubits": 20,
+            "num_random_trials": 25,
+            "qaoa_layers": [10],
+            "seed": 123,
+            "shots": 1000,
+            "trials": 10
+        }
+    },
+    {
+        "name": "LR_QAOA_1D_50",
+        "config": {
+            "benchmark_name": "Linear Ramp QAOA",
+            "confidence_level": 0.999,
+            "delta_beta": 0.3,
+            "delta_gamma": 0.6,
+            "graph_type": "1D",
+            "num_qubits": 50,
+            "num_random_trials": 25,
+            "qaoa_layers": [10],
+            "seed": 123,
+            "shots": 1000,
+            "trials": 10
+        }
+    },
+    {
+        "name": "LR_QAOA_1D_100",
+        "config": {
+            "benchmark_name": "Linear Ramp QAOA",
+            "confidence_level": 0.999,
+            "delta_beta": 0.3,
+            "delta_gamma": 0.6,
+            "graph_type": "1D",
+            "num_qubits": 100,
+            "num_random_trials": 25,
+            "qaoa_layers": [10],
+            "seed": 123,
+            "shots": 1000,
+            "trials": 10
+        }
+    }
+  ]
+}

--- a/tests/unit/benchmarks/test_lr-qaoa.py
+++ b/tests/unit/benchmarks/test_lr-qaoa.py
@@ -1,7 +1,11 @@
 import pytest
 import networkx as nx
 import random
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from metriq_gym.benchmarks.lr_qaoa import (
+    LinearRampQAOA,
     prepare_qaoa_circuit,
     calc_stats,
     cost_maxcut,
@@ -10,6 +14,26 @@ from metriq_gym.benchmarks.lr_qaoa import (
 )
 from metriq_gym.benchmarks.lr_qaoa import LinearRampQAOAData
 from metriq_gym.circuits import distribute_edges, SWAP_pairs
+from metriq_gym.exceptions import DeviceCapacityError
+
+
+def test_lr_qaoa_rejects_oversized_workload_before_connectivity_lookup():
+    benchmark = LinearRampQAOA(
+        SimpleNamespace(),
+        SimpleNamespace(num_qubits=50),
+    )
+    device = SimpleNamespace(
+        id="arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1",
+        num_qubits=36,
+    )
+
+    with (
+        patch("metriq_gym.benchmarks.lr_qaoa.connectivity_graph") as connectivity_mock,
+        pytest.raises(DeviceCapacityError, match="Requested 50 qubits"),
+    ):
+        benchmark._build_circuits(device)
+
+    connectivity_mock.assert_not_called()
 
 
 @pytest.mark.parametrize("num_qubits, qaoa_layers", [(5, [10]), [10, [5, 7]]])

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -5,7 +5,7 @@ Tests the version and connectivity_graph functions for different device types
 using mocked qBraid device objects.
 """
 
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
 
 import pytest
 import rustworkx as rx
@@ -20,6 +20,7 @@ from metriq_gym.qplatform.device import (
     connectivity_graph,
     normalized_metadata,
     pruned_connectivity_graph,
+    validate_qubit_capacity,
 )
 
 
@@ -196,6 +197,14 @@ class TestVersionFunction:
         provider = LocalProvider()
         device = provider.get_device("aer_simulator")
         assert isinstance(version(device), str)
+
+
+class TestValidateQubitCapacity:
+    def test_missing_num_qubits_is_ignored(self):
+        device = Mock(spec=AzureQuantumDevice)
+        type(device).num_qubits = PropertyMock(side_effect=AttributeError("num_qubits"))
+
+        validate_qubit_capacity(device, required_qubits=50)
 
 
 class TestConnectivityGraphFunction:

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -229,6 +229,37 @@ class TestConnectivityGraphFunction:
         expected_edges = mock_num_qubits * (mock_num_qubits - 1) // 2
         assert result.num_edges() == expected_edges
 
+    def test_braket_ionq_connectivity_without_topology_uses_complete_graph(self):
+        mock_num_qubits = 36
+        device = Mock(spec=BraketDevice)
+        mock_internal_device = Mock()
+        mock_internal_device.topology_graph = None
+        device._device = mock_internal_device
+        device._provider_name = "IonQ"
+        device.id = "arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1"
+        device.num_qubits = mock_num_qubits
+
+        result = connectivity_graph(device)
+
+        assert isinstance(result, rx.PyGraph)
+        assert result.num_nodes() == mock_num_qubits
+        expected_edges = mock_num_qubits * (mock_num_qubits - 1) // 2
+        assert result.num_edges() == expected_edges
+
+    def test_braket_missing_topology_for_sparse_device_raises_clear_error(self):
+        device = Mock(spec=BraketDevice)
+        mock_internal_device = Mock()
+        mock_internal_device.topology_graph = None
+        device._device = mock_internal_device
+        device._provider_name = "Rigetti"
+        device.id = "arn:aws:braket:us-west-1::device/qpu/rigetti/Ankaa-3"
+        device.num_qubits = 84
+
+        with pytest.raises(NotImplementedError) as exc_info:
+            connectivity_graph(device)
+
+        assert "Connectivity graph not available for Braket device" in str(exc_info.value)
+
     def test_azure_device_connectivity(self, mock_azure_device):
         result = connectivity_graph(mock_azure_device)
         assert isinstance(result, rx.PyGraph)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import json
 from pydantic import BaseModel
 from qbraid import QbraidError
-from qbraid.runtime import JobStatus
+from qbraid.runtime import BraketDevice, JobStatus
 from qbraid.runtime.result_data import GateModelResultData, MeasCount
 from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult, BenchmarkScore
 from metriq_gym.run import (
@@ -77,6 +77,36 @@ def test_setup_device_success(mock_provider, mock_device, patch_load_provider):
 
     mock_provider.get_device.assert_called_once_with(backend_name)
     assert device == mock_device
+
+
+def test_setup_device_disables_validation_for_braket_without_parsed_capabilities(
+    mock_provider, patch_load_provider, caplog
+):
+    device = MagicMock(spec=BraketDevice)
+    device.id = "arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1"
+    device._device = SimpleNamespace(properties=None)
+    mock_provider.get_device.return_value = device
+    caplog.set_level(logging.WARNING)
+
+    result = setup_device("aws", device.id)
+
+    assert result == device
+    device.set_options.assert_called_once_with(validate=False)
+    assert "could not be parsed" in caplog.text
+
+
+def test_setup_device_keeps_validation_for_braket_with_parsed_capabilities(
+    mock_provider, patch_load_provider
+):
+    device = MagicMock(spec=BraketDevice)
+    device.id = "arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1"
+    device._device = SimpleNamespace(properties=object())
+    mock_provider.get_device.return_value = device
+
+    result = setup_device("aws", device.id)
+
+    assert result == device
+    device.set_options.assert_not_called()
 
 
 @patch("metriq_gym.run.get_providers")

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+import os
 import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,7 @@ from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult, Benc
 from metriq_gym.run import (
     setup_device,
     dispatch_job,
+    dispatch_suite,
     fetch_result,
     estimate_job,
     _export_raw_debug_data,
@@ -77,6 +79,32 @@ def test_setup_device_success(mock_provider, mock_device, patch_load_provider):
 
     mock_provider.get_device.assert_called_once_with(backend_name)
     assert device == mock_device
+
+
+@pytest.mark.parametrize("configured_region", [None, "eu-west-2"])
+def test_setup_device_uses_braket_arn_region_temporarily(
+    configured_region, mock_provider, mock_device, patch_load_provider, monkeypatch
+):
+    arn = "arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1"
+    observed_regions = []
+
+    if configured_region is None:
+        monkeypatch.delenv("AWS_REGION", raising=False)
+    else:
+        monkeypatch.setenv("AWS_REGION", configured_region)
+
+    def get_device(device_name):
+        observed_regions.append(os.environ.get("AWS_REGION"))
+        assert device_name == arn
+        return mock_device
+
+    mock_provider.get_device.side_effect = get_device
+
+    device = setup_device("aws", arn)
+
+    assert device == mock_device
+    assert observed_regions == ["us-east-1"]
+    assert os.environ.get("AWS_REGION") == configured_region
 
 
 def test_setup_device_disables_validation_for_braket_without_parsed_capabilities(
@@ -209,6 +237,56 @@ def test_dispatch_missing_config_file(mock_exists, mock_args, mock_job_manager, 
         assert "Configuration file not found" in captured.out
 
 
+def test_dispatch_suite_skips_benchmark_exceeding_device_capacity(
+    tmp_path, monkeypatch, mock_job_manager, capsys
+):
+    suite_file = tmp_path / "oversized_suite.json"
+    suite_file.write_text(
+        json.dumps(
+            {
+                "name": "lr_qaoa_scale_suite",
+                "benchmarks": [
+                    {
+                        "name": "LR_QAOA_1D_50",
+                        "config": {
+                            "benchmark_name": "Linear Ramp QAOA",
+                            "graph_type": "1D",
+                            "num_qubits": 50,
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    device = SimpleNamespace(
+        id="arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1",
+        num_qubits=36,
+    )
+    args = SimpleNamespace(
+        provider="aws",
+        device=device.id,
+        suite_config=str(suite_file),
+    )
+    registry = MagicMock()
+    registry.get_available_benchmarks.return_value = ["Linear Ramp QAOA"]
+    setup_benchmark_mock = MagicMock(
+        side_effect=AssertionError("setup_benchmark must not be called")
+    )
+
+    monkeypatch.setattr("metriq_gym.run.setup_device", lambda *_: device)
+    monkeypatch.setattr("metriq_gym.run._lazy_registry", lambda: registry)
+    monkeypatch.setattr("metriq_gym.run.setup_benchmark", setup_benchmark_mock)
+
+    dispatch_suite(args, mock_job_manager)
+
+    output = capsys.readouterr().out
+    assert "Requested 50 qubits" in output
+    assert "supports only 36" in output
+    assert "Successfully dispatched 0/1 benchmarks" in output
+    setup_benchmark_mock.assert_not_called()
+    mock_job_manager.add_job.assert_not_called()
+
+
 def test_estimate_job_quantinuum_defaults(monkeypatch, capsys):
     class DummyParams(BaseModel):
         benchmark_name: str = "WIT"
@@ -221,7 +299,11 @@ def test_estimate_job_quantinuum_defaults(monkeypatch, capsys):
     monkeypatch.setattr("metriq_gym.run.load_and_validate", lambda *_: DummyParams())
     monkeypatch.setattr(
         "metriq_gym.run.setup_device",
-        lambda *_, **__: SimpleNamespace(id="H1-1", profile=SimpleNamespace(basis_gates=[])),
+        lambda *_, **__: SimpleNamespace(
+            id="H1-1",
+            num_qubits=20,
+            profile=SimpleNamespace(basis_gates=[]),
+        ),
     )
 
     # Mock the registry


### PR DESCRIPTION
# Description

Fixes a bunch of small issues that were met while trying to run LR-QAOA workloads on IonQ Forte AWS Braket support and prevents unsupported benchmark workloads from performing expensive setup work.

Bonus changes include:

- Infer the AWS region from Braket device ARNs during initialization.
- Add early qubit-capacity validation for jobs, suites, and resource estimation.

Forte-1 supports 36 qubits, so 50 and 100-qubit workloads are now rejected immediately, while supported suite entries continue normally.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Added unit tests
- Dispatched LR-QAOA suite to IonQ Forte-1 (still QUEUED)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)