### PR TITLE
Restrict setuptools_scm version discovery to release tags

### DIFF
--- a/docs/content/development/developer-guide.md
+++ b/docs/content/development/developer-guide.md
@@ -243,6 +243,22 @@ Releases are managed by maintainers:
 2. CI builds and publishes to PyPI
 3. Documentation is deployed to GitHub Pages
 
+### Tag naming requirement
+
+Release tags **must** follow the `v<digit>` scheme, i.e. `v<major>.<minor>.<patch>`
+with an optional pre-release suffix (e.g. `v0.7.1`, `v0.8.0rc1`). `setuptools_scm`
+is configured to only consider tags matching the glob `v[0-9]*` when deriving the
+package version, so:
+
+- A release cut from a conforming tag builds a clean version (e.g. `0.7.1`) that
+  PyPI accepts.
+- A release cut from a non-conforming tag (e.g. `release-1.0`) would fall back to
+  the nearest conforming tag and produce a dev version with a `+g<hash>` local
+  segment, which PyPI rejects on upload.
+
+Tags that are not releases (e.g. `metriq-paper-v1`) must **not** match `v[0-9]*`;
+they are ignored by versioning, so they can be created freely.
+
 ## Getting Help
 
 - [Issue Tracker](https://github.com/unitaryfoundation/metriq-gym/issues)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ include-package-data = true
 write_to = "metriq_gym/_version.py"
 write_to_template = "__version__ = \"{version}\"\n"
 fallback_version = "0.0.0"
+git_describe_command = "git describe --dirty --tags --long --match v[0-9]*"
 
 [project.entry-points."qbraid.providers"]
 local = "metriq_gym.local.provider:LocalProvider"


### PR DESCRIPTION
## Issue

The package version is derived by setuptools_scm from the nearest git tag using `git describe`, which by default considers **all** tags. The non-release tag `metriq-paper-v1` is newer in history than the latest release tag `v0.7.0`, so `git describe` resolves to it. setuptools_scm parses the trailing `1` as the version and guesses the next release, so any checkout after that tag reports:

```
2.dev8+g0ccc671f8
```

instead of a version anchored to the actual latest release. This misleading version also propagates into the `app_version` field recorded in every benchmark result.

## Fix

Configure setuptools_scm to only consider release-style tags when running `git describe`:

```toml
[tool.setuptools_scm]
git_describe_command = "git describe --dirty --tags --long --match v[0-9]*"
```

With this change the same checkout reports `0.7.1.dev23+g0ccc671` — correctly anchored to `v0.7.0` (23 commits ahead, standard guess-next-version scheme). Checkouts at a release tag report the clean version, e.g. `0.7.0`.

Verified locally by rebuilding and checking `importlib.metadata.version("metriq-gym")` and the generated `metriq_gym/_version.py` before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)