### PR TITLE
Normalize AWS and Braket provider aliases

### DIFF
--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -148,7 +148,7 @@ ProviderOption = Annotated[
     typer.Option(
         "--provider",
         "-p",
-        help="Provider name (e.g., ibm, braket, azure, ionq, local)",
+        help="Provider name (e.g., ibm, aws, azure, ionq, local; braket aliases aws)",
     ),
 ]
 

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from metriq_gym.benchmarks.benchmark import BenchmarkResult
 from metriq_gym.job_manager import MetriqGymJob
+from metriq_gym.platform import canonical_device_name, canonical_provider_name
 
 
 class BaseExporter(ABC):
@@ -56,25 +57,13 @@ class BaseExporter(ABC):
         platform_info.setdefault("provider", self.metriq_gym_job.provider_name)
         platform_info.setdefault("device", self.metriq_gym_job.device_name)
 
-        # Normalize AWS/Braket device identifiers for upload: use last two ARN path
-        # segments, joined by underscore and lowercased (e.g., iqm_emerald).
-        provider_val = str(platform_info.get("provider") or "").strip()
-        device_val = str(platform_info.get("device") or "").strip()
-
-        def _is_aws_provider(name: str) -> bool:
-            return name.lower() == "aws"
-
-        def _simplify_arn_device(device: str) -> str:
-            # Split on '/' and take the last two non-empty segments when available.
-            parts = [p for p in device.split("/") if p]
-            if len(parts) >= 2:
-                simplified = f"{parts[-2]}_{parts[-1]}"
-            else:
-                simplified = device
-            return simplified.lower()
-
-        if provider_val and _is_aws_provider(provider_val) and device_val:
-            platform_info["device"] = _simplify_arn_device(device_val)
+        provider_val = canonical_provider_name(str(platform_info.get("provider") or ""))
+        device_val = canonical_device_name(
+            provider_val,
+            str(platform_info.get("device") or ""),
+        )
+        platform_info["provider"] = provider_val
+        platform_info["device"] = device_val
 
         device_metadata = self._derive_device_metadata()
         if device_metadata:

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -14,6 +14,7 @@ from typing import Any, Sequence
 from tabulate import tabulate
 from metriq_gym.constants import JobType
 from metriq_gym.paths import get_data_db_path
+from metriq_gym.platform import canonical_device_name, canonical_provider_name
 
 
 logger = logging.getLogger(__name__)
@@ -42,14 +43,22 @@ class MetriqGymJob:
         - If platform is missing, populate from provider_name/device_name.
         - If platform exists but lacks keys, backfill them from provider/device fields.
         """
+        self.provider_name = canonical_provider_name(self.provider_name)
+        self.device_name = canonical_device_name(self.provider_name, self.device_name)
+
         plat = self.platform or {}
         if not plat:
             plat = {"provider": self.provider_name, "device": self.device_name}
         else:
-            if "provider" not in plat:
-                plat["provider"] = self.provider_name
-            if "device" not in plat:
-                plat["device"] = self.device_name
+            platform_provider = canonical_provider_name(
+                str(plat.get("provider") or self.provider_name)
+            )
+            platform_device = canonical_device_name(
+                platform_provider,
+                str(plat.get("device") or self.device_name),
+            )
+            plat["provider"] = platform_provider
+            plat["device"] = platform_device
         self.platform = plat
 
     def num_qubits(self) -> int | None:

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -38,27 +38,20 @@ class MetriqGymJob:
     runtime_seconds: float | None = None
 
     def __post_init__(self) -> None:
-        """Keep platform and provider/device fields in sync on initialization.
+        """Populate the canonical dataset platform without rewriting runtime identifiers.
 
-        - If platform is missing, populate from provider_name/device_name.
-        - If platform exists but lacks keys, backfill them from provider/device fields.
+        ``provider_name`` and ``device_name`` retain the values needed to address the
+        runtime provider and device. The corresponding ``platform`` values are stable
+        dataset keys and may intentionally omit runtime details such as an AWS region.
         """
-        self.provider_name = canonical_provider_name(self.provider_name)
-        self.device_name = canonical_device_name(self.provider_name, self.device_name)
-
-        plat = self.platform or {}
-        if not plat:
-            plat = {"provider": self.provider_name, "device": self.device_name}
-        else:
-            platform_provider = canonical_provider_name(
-                str(plat.get("provider") or self.provider_name)
-            )
-            platform_device = canonical_device_name(
-                platform_provider,
-                str(plat.get("device") or self.device_name),
-            )
-            plat["provider"] = platform_provider
-            plat["device"] = platform_device
+        plat = dict(self.platform or {})
+        platform_provider = canonical_provider_name(str(plat.get("provider") or self.provider_name))
+        platform_device = canonical_device_name(
+            platform_provider,
+            str(plat.get("device") or self.device_name),
+        )
+        plat["provider"] = platform_provider
+        plat["device"] = platform_device
         self.platform = plat
 
     def num_qubits(self) -> int | None:

--- a/metriq_gym/platform.py
+++ b/metriq_gym/platform.py
@@ -1,0 +1,26 @@
+"""Canonical platform identifiers shared across runtime and export paths."""
+
+AWS_PROVIDER = "aws"
+AWS_PROVIDER_ALIASES = frozenset({AWS_PROVIDER, "braket"})
+
+
+def canonical_provider_name(provider: str) -> str:
+    """Return the canonical provider identifier while accepting known aliases."""
+    stripped = provider.strip()
+    if stripped.lower() in AWS_PROVIDER_ALIASES:
+        return AWS_PROVIDER
+    return stripped
+
+
+def canonical_device_name(provider: str, device: str) -> str:
+    """Normalize device identifiers whose provider has a canonical representation."""
+    stripped = device.strip()
+    if canonical_provider_name(provider) != AWS_PROVIDER:
+        return stripped
+
+    # Braket device IDs are ARNs. Dataset identifiers use the final two ARN path
+    # segments, joined by an underscore (for example, ``iqm_emerald``).
+    parts = [part for part in stripped.split("/") if part]
+    if len(parts) >= 2:
+        stripped = f"{parts[-2]}_{parts[-1]}"
+    return stripped.lower()

--- a/metriq_gym/platform.py
+++ b/metriq_gym/platform.py
@@ -1,11 +1,11 @@
-"""Canonical platform identifiers shared across runtime and export paths."""
+"""Canonical provider aliases and dataset-facing device identifiers."""
 
 AWS_PROVIDER = "aws"
 AWS_PROVIDER_ALIASES = frozenset({AWS_PROVIDER, "braket"})
 
 
 def canonical_provider_name(provider: str) -> str:
-    """Return the canonical provider identifier while accepting known aliases."""
+    """Canonicalize known provider aliases while preserving all other identifiers."""
     stripped = provider.strip()
     if stripped.lower() in AWS_PROVIDER_ALIASES:
         return AWS_PROVIDER
@@ -13,13 +13,14 @@ def canonical_provider_name(provider: str) -> str:
 
 
 def canonical_device_name(provider: str, device: str) -> str:
-    """Normalize device identifiers whose provider has a canonical representation."""
+    """Return a stable dataset key without changing the runtime device address."""
     stripped = device.strip()
     if canonical_provider_name(provider) != AWS_PROVIDER:
         return stripped
 
-    # Braket device IDs are ARNs. Dataset identifiers use the final two ARN path
-    # segments, joined by an underscore (for example, ``iqm_emerald``).
+    # Braket device IDs are ARNs. Dataset identity intentionally ignores the ARN
+    # region and uses the final two path segments (for example, ``iqm_emerald``).
+    # The full, case-sensitive runtime ARN remains on MetriqGymJob.device_name.
     parts = [part for part in stripped.split("/") if part]
     if len(parts) >= 2:
         stripped = f"{parts[-2]}_{parts[-1]}"

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -26,6 +26,7 @@ from metriq_gym.resource_estimation import (
 from metriq_gym.suite_parser import parse_suite_file
 from metriq_gym.exceptions import QBraidSetupError
 from metriq_gym.upload_paths import default_upload_dir, job_filename, suite_filename
+from metriq_gym.platform import canonical_provider_name
 
 
 if TYPE_CHECKING:
@@ -54,7 +55,7 @@ def load_provider(provider_name: str):
     """
     from qbraid.runtime import load_provider as _load_provider
 
-    return _load_provider(provider_name)
+    return _load_provider(canonical_provider_name(provider_name))
 
 
 def get_providers() -> list[str]:
@@ -74,7 +75,7 @@ def load_job(job_id: str, *, provider: str, **kwargs):
     """
     from qbraid.runtime import load_job as _load_job
 
-    return _load_job(job_id, provider=provider, **kwargs)
+    return _load_job(job_id, provider=canonical_provider_name(provider), **kwargs)
 
 
 def job_status(quantum_job):
@@ -123,7 +124,7 @@ def setup_device(provider_name: str, device_name: str):
         raise QBraidSetupError("Provider not found")
 
     try:
-        provider = load_provider(provider_name)
+        provider = load_provider(canonical_provider_name(provider_name))
     except QbraidError:
         providers = ", ".join(get_providers())
         logger.error(f"No provider matching the name '{provider_name}' found.")

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -153,7 +153,7 @@ def setup_device(provider_name: str, device_name: str):
         raise QBraidSetupError("Provider not found")
 
     try:
-        provider = load_provider(canonical_provider_name(provider_name))
+        provider = load_provider(provider_name)
     except QbraidError:
         providers = ", ".join(get_providers())
         logger.error(f"No provider matching the name '{provider_name}' found.")

--- a/metriq_gym/upload_paths.py
+++ b/metriq_gym/upload_paths.py
@@ -6,6 +6,8 @@ import hashlib
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from metriq_gym.platform import canonical_device_name, canonical_provider_name
+
 if TYPE_CHECKING:
     from metriq_gym.job_manager import MetriqGymJob
 
@@ -35,8 +37,9 @@ def path_component(value: str | None) -> str:
 
 def default_upload_dir(version: str, provider: str, device: str) -> str:
     """Provider/device-aware default upload directory to avoid PR conflicts."""
-    provider_part = path_component(provider)
-    device_part = path_component(device)
+    canonical_provider = canonical_provider_name(provider)
+    provider_part = path_component(canonical_provider)
+    device_part = path_component(canonical_device_name(canonical_provider, device))
     return f"metriq-gym/{minor_series_label(version)}/{provider_part}/{device_part}"
 
 

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import pytest
+
+from metriq_gym.benchmarks.benchmark import BenchmarkResult
+from metriq_gym.constants import JobType
+from metriq_gym.exporters.dict_exporter import DictExporter
+from metriq_gym.job_manager import MetriqGymJob
+from metriq_gym.platform import canonical_device_name, canonical_provider_name
+
+
+CEPHEUS_ARN = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
+
+
+@pytest.mark.parametrize("alias", ["aws", "AWS", "braket", "Braket"])
+def test_aws_provider_aliases_share_canonical_identity(alias):
+    assert canonical_provider_name(alias) == "aws"
+    assert canonical_device_name(alias, CEPHEUS_ARN) == "rigetti_cepheus-1-108q"
+
+
+def test_braket_job_and_export_use_canonical_platform_identity():
+    job = MetriqGymJob(
+        id="job-1",
+        job_type=JobType.WIT,
+        params={},
+        data={},
+        provider_name="braket",
+        device_name=CEPHEUS_ARN,
+        platform={"provider": "braket", "device": CEPHEUS_ARN},
+        dispatch_time=datetime(2026, 7, 15),
+    )
+
+    assert job.provider_name == "aws"
+    assert job.device_name == "rigetti_cepheus-1-108q"
+    assert job.platform == {
+        "provider": "aws",
+        "device": "rigetti_cepheus-1-108q",
+    }
+
+    payload = DictExporter(job, BenchmarkResult()).export()
+    assert payload["platform"] == {
+        "provider": "aws",
+        "device": "rigetti_cepheus-1-108q",
+    }

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 
 import pytest
 
@@ -18,7 +19,20 @@ def test_aws_provider_aliases_share_canonical_identity(alias):
     assert canonical_device_name(alias, CEPHEUS_ARN) == "rigetti_cepheus-1-108q"
 
 
-def test_braket_job_and_export_use_canonical_platform_identity():
+def test_unknown_provider_identifiers_are_preserved():
+    assert canonical_provider_name("IBM") == "IBM"
+    assert canonical_provider_name(" custom-provider ") == "custom-provider"
+
+
+def test_braket_dataset_device_identity_is_region_independent():
+    alternate_region_arn = CEPHEUS_ARN.replace("us-west-1", "us-east-1")
+
+    assert canonical_device_name("aws", CEPHEUS_ARN) == canonical_device_name(
+        "aws", alternate_region_arn
+    )
+
+
+def test_braket_job_preserves_runtime_identifiers_and_exports_canonical_platform():
     job = MetriqGymJob(
         id="job-1",
         job_type=JobType.WIT,
@@ -30,8 +44,8 @@ def test_braket_job_and_export_use_canonical_platform_identity():
         dispatch_time=datetime(2026, 7, 15),
     )
 
-    assert job.provider_name == "aws"
-    assert job.device_name == "rigetti_cepheus-1-108q"
+    assert job.provider_name == "braket"
+    assert job.device_name == CEPHEUS_ARN
     assert job.platform == {
         "provider": "aws",
         "device": "rigetti_cepheus-1-108q",
@@ -42,3 +56,14 @@ def test_braket_job_and_export_use_canonical_platform_identity():
         "provider": "aws",
         "device": "rigetti_cepheus-1-108q",
     }
+
+    legacy_record = json.loads(job.serialize())
+    legacy_record.pop("platform")
+    restored_job = MetriqGymJob.deserialize(json.dumps(legacy_record))
+    assert restored_job.provider_name == "braket"
+    assert restored_job.device_name == CEPHEUS_ARN
+    assert restored_job.platform == job.platform
+
+    saved_record = json.loads(restored_job.serialize())
+    assert saved_record["provider_name"] == "braket"
+    assert saved_record["device_name"] == CEPHEUS_ARN

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -79,6 +79,21 @@ def test_setup_device_success(mock_provider, mock_device, patch_load_provider):
     assert device == mock_device
 
 
+@pytest.mark.parametrize("provider_alias", ["aws", "braket"])
+def test_setup_device_uses_canonical_aws_provider(
+    provider_alias, mock_provider, mock_device, monkeypatch
+):
+    loaded_providers = []
+    mock_provider.get_device.return_value = mock_device
+    monkeypatch.setattr(
+        "metriq_gym.run.load_provider",
+        lambda provider: loaded_providers.append(provider) or mock_provider,
+    )
+
+    assert setup_device(provider_alias, "device-arn") == mock_device
+    assert loaded_providers == ["aws"]
+
+
 @patch("metriq_gym.run.get_providers")
 def test_setup_device_invalid_provider(get_providers_patch, caplog):
     get_providers_patch.return_value = ["supported_provider"]

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -12,6 +12,7 @@ from qbraid.runtime import BraketDevice, JobStatus
 from qbraid.runtime.result_data import GateModelResultData, MeasCount
 from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult, BenchmarkScore
 from metriq_gym.run import (
+    load_provider,
     setup_device,
     dispatch_job,
     dispatch_suite,
@@ -138,7 +139,20 @@ def test_setup_device_keeps_validation_for_braket_with_parsed_capabilities(
 
 
 @pytest.mark.parametrize("provider_alias", ["aws", "braket"])
-def test_setup_device_uses_canonical_aws_provider(
+def test_load_provider_uses_canonical_aws_provider(provider_alias, monkeypatch):
+    loaded_providers = []
+    provider = object()
+    monkeypatch.setattr(
+        "qbraid.runtime.load_provider",
+        lambda provider_name: loaded_providers.append(provider_name) or provider,
+    )
+
+    assert load_provider(provider_alias) is provider
+    assert loaded_providers == ["aws"]
+
+
+@pytest.mark.parametrize("provider_alias", ["aws", "braket"])
+def test_setup_device_delegates_provider_alias_to_load_provider(
     provider_alias, mock_provider, mock_device, monkeypatch
 ):
     loaded_providers = []
@@ -149,7 +163,7 @@ def test_setup_device_uses_canonical_aws_provider(
     )
 
     assert setup_device(provider_alias, "device-arn") == mock_device
-    assert loaded_providers == ["aws"]
+    assert loaded_providers == [provider_alias]
 
 
 @patch("metriq_gym.run.get_providers")

--- a/tests/unit/test_upload_paths.py
+++ b/tests/unit/test_upload_paths.py
@@ -29,6 +29,30 @@ def test_default_upload_dir_builds_expected_path():
     assert path == "metriq-gym/v0.4/aws_braket/rigetti_aspen_m2"
 
 
+def test_default_upload_dir_uses_canonicalized_job_platform():
+    job = MetriqGymJob(
+        id="job-aws",
+        job_type=JobType.WIT,
+        params={},
+        data={},
+        provider_name="braket",
+        device_name="arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q",
+        dispatch_time=datetime(2026, 7, 15),
+    )
+
+    path = default_upload_dir("0.7.0", job.provider_name, job.device_name)
+    assert path == "metriq-gym/v0.7/aws/rigetti_cepheus-1-108q"
+
+
+def test_default_upload_dir_accepts_braket_alias_directly():
+    path = default_upload_dir(
+        "0.7.0",
+        "braket",
+        "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q",
+    )
+    assert path == "metriq-gym/v0.7/aws/rigetti_cepheus-1-108q"
+
+
 def test_job_filename_structure():
     when = datetime(2024, 1, 2, 3, 4, 5)
 

--- a/tests/unit/test_upload_paths.py
+++ b/tests/unit/test_upload_paths.py
@@ -29,7 +29,7 @@ def test_default_upload_dir_builds_expected_path():
     assert path == "metriq-gym/v0.4/aws_braket/rigetti_aspen_m2"
 
 
-def test_default_upload_dir_uses_canonicalized_job_platform():
+def test_default_upload_dir_canonicalizes_job_runtime_identifiers():
     job = MetriqGymJob(
         id="job-aws",
         job_type=JobType.WIT,


### PR DESCRIPTION
## Summary

- accept both `aws` and `braket` while using `aws` as the canonical provider identifier
- canonicalize Braket ARNs to stable device names in persisted jobs, exports, runtime loading, and upload paths
- update CLI guidance and add regression coverage for the Cepheus ARN case
- preserve compatibility with existing persisted `braket` jobs through job initialization/deserialization

Companion data-side hardening: unitaryfoundation/metriq-data#470. The PRs are complementary but can merge independently; merging the data PR first is recommended.

## Validation

- pre-commit hooks: Ruff, Ruff format, mypy, and deptry passed
- `pytest -q -m "not e2e"` — 375 passed, 15 deselected
- focused platform/runtime/upload-path tests — 33 passed