### PR TITLE
Align QFT qubit parameters with other benchmarks

### DIFF
--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -213,10 +213,18 @@ def get_circuits_and_metrics(
     benchmark = import_benchmark_module(benchmark_name)
 
     # Call the QED-C submodule to get the circuits and creation information.
-    # Conver to QED-C parameter naming conventions.
+    # Convert to QED-C parameter naming conventions.
     qedc_params = params.copy()
     if "shots" in qedc_params:
         qedc_params["num_shots"] = qedc_params.pop("shots")
+    # A single fixed qubit count (num_qubits) maps to a one-point QED-C sweep.
+    # This lets a benchmark expose the same num_qubits parameter as the rest of
+    # the suite while still driving QED-C's range-based run().
+    if "num_qubits" in qedc_params:
+        num_qubits = qedc_params.pop("num_qubits")
+        qedc_params["min_qubits"] = num_qubits
+        qedc_params["max_qubits"] = num_qubits
+        qedc_params["skip_qubits"] = 1
     circuits, circuit_metrics = benchmark.run(
         **qedc_params,
         api="qiskit",
@@ -247,7 +255,12 @@ def calculate_accuracy_score(circuit_metrics: QEDC_Metrics) -> tuple[float, floa
     Returns:
         values: the score and the uncertainty.
     """
-    # Obtain the average fidelity and standard deviation for each qubit size (group) in the sweep.
+    # aggregate_metrics() appends to the module-global group_metrics, so reset that
+    # accumulator first. Without this, polling several QED-C jobs in one process
+    # (for example a suite that sweeps QFT over qubit counts) would aggregate each
+    # job's fidelities on top of the previous jobs' and inflate the score. Only
+    # group_metrics is reset; circuit_metrics holds the per-job data being scored.
+    metrics.group_metrics = {key: [] for key in metrics.group_metrics}
     metrics.circuit_metrics = circuit_metrics
     metrics.aggregate_metrics()
     avgs = metrics.group_metrics["avg_fidelities"]

--- a/metriq_gym/schemas/examples/quantum_fourier_transform.example.json
+++ b/metriq_gym/schemas/examples/quantum_fourier_transform.example.json
@@ -1,9 +1,7 @@
 {
     "benchmark_name": "Quantum Fourier Transform",
     "shots": 1000,
-    "min_qubits": 2,
-    "max_qubits": 6,
-    "skip_qubits": 1,
+    "num_qubits": 5,
     "max_circuits": 3,
     "method": 1,
     "use_midcircuit_measurement": false

--- a/metriq_gym/schemas/quantum_fourier_transform.schema.json
+++ b/metriq_gym/schemas/quantum_fourier_transform.schema.json
@@ -18,26 +18,12 @@
       "minimum": 1,
       "examples": [5000]
     },
-    "min_qubits": {
+    "num_qubits": {
       "type": "integer",
-      "description": "Minimum number of qubits to start generating circuits for the benchmark.",
-      "default": 2,
+      "description": "Number of qubits for the benchmark circuits. A single QFT run uses one fixed qubit count, matching the other benchmarks; sweeps over multiple qubit counts are defined at the suite level.",
+      "default": 5,
       "minimum": 2,
-      "examples": [4]
-    },
-    "max_qubits": {
-      "type": "integer",
-      "description": "Maximum number of qubits to stop generating circuits for the benchmark.",
-      "default": 6,
-      "minimum": 2,
-      "examples": [7]
-    },
-    "skip_qubits": {
-      "type": "integer",
-      "description": "The step size for generating circuits from the min to max qubit sizes. ",
-      "default": 1,
-      "minimum": 1,
-      "examples": [2]
+      "examples": [10]
     },
     "max_circuits": {
       "type": "integer",

--- a/metriq_gym/suites/qft_sweep.json
+++ b/metriq_gym/suites/qft_sweep.json
@@ -1,28 +1,36 @@
 {
     "name": "qft_sweep",
-    "description": "Quantum Fourier Transform swept over qubit counts. Each entry is a single fixed-qubit-count QFT run; the sweep is defined here at the suite level rather than inside the benchmark.",
+    "description": "Quantum Fourier Transform swept over the {10, 20, 30, 50} qubit counts used in the metriq-gym paper (arXiv:2603.08680, section IV.B.4). Each entry is a single fixed-qubit-count QFT run; the sweep is defined here at the suite level rather than inside the benchmark.",
     "benchmarks": [
         {
-            "name": "qft_3_qubits",
+            "name": "qft_10_qubits",
             "config": {
                 "benchmark_name": "Quantum Fourier Transform",
-                "num_qubits": 3,
+                "num_qubits": 10,
                 "shots": 1000
             }
         },
         {
-            "name": "qft_4_qubits",
+            "name": "qft_20_qubits",
             "config": {
                 "benchmark_name": "Quantum Fourier Transform",
-                "num_qubits": 4,
+                "num_qubits": 20,
                 "shots": 1000
             }
         },
         {
-            "name": "qft_5_qubits",
+            "name": "qft_30_qubits",
             "config": {
                 "benchmark_name": "Quantum Fourier Transform",
-                "num_qubits": 5,
+                "num_qubits": 30,
+                "shots": 1000
+            }
+        },
+        {
+            "name": "qft_50_qubits",
+            "config": {
+                "benchmark_name": "Quantum Fourier Transform",
+                "num_qubits": 50,
                 "shots": 1000
             }
         }

--- a/metriq_gym/suites/qft_sweep.json
+++ b/metriq_gym/suites/qft_sweep.json
@@ -1,0 +1,30 @@
+{
+    "name": "qft_sweep",
+    "description": "Quantum Fourier Transform swept over qubit counts. Each entry is a single fixed-qubit-count QFT run; the sweep is defined here at the suite level rather than inside the benchmark.",
+    "benchmarks": [
+        {
+            "name": "qft_3_qubits",
+            "config": {
+                "benchmark_name": "Quantum Fourier Transform",
+                "num_qubits": 3,
+                "shots": 1000
+            }
+        },
+        {
+            "name": "qft_4_qubits",
+            "config": {
+                "benchmark_name": "Quantum Fourier Transform",
+                "num_qubits": 4,
+                "shots": 1000
+            }
+        },
+        {
+            "name": "qft_5_qubits",
+            "config": {
+                "benchmark_name": "Quantum Fourier Transform",
+                "num_qubits": 5,
+                "shots": 1000
+            }
+        }
+    ]
+}

--- a/tests/unit/benchmarks/test_qedc_benchmarks.py
+++ b/tests/unit/benchmarks/test_qedc_benchmarks.py
@@ -1,0 +1,62 @@
+"""Tests for the QED-C benchmark wrapper, focused on QFT's fixed qubit count."""
+
+import pytest
+
+from metriq_gym.benchmarks.qedc_benchmarks import (
+    calculate_accuracy_score,
+    get_circuits_and_metrics,
+)
+
+
+def test_qft_num_qubits_builds_single_qubit_group():
+    """A QFT run with a fixed num_qubits produces one QED-C qubit group."""
+    circuits, circuit_metrics, circuit_identifiers = get_circuits_and_metrics(
+        benchmark_name="Quantum Fourier Transform",
+        params={
+            "num_qubits": 4,
+            "shots": 100,
+            "max_circuits": 2,
+            "method": 1,
+            "use_midcircuit_measurement": False,
+        },
+    )
+
+    # Exactly one qubit group, and it is the requested size.
+    assert list(circuit_metrics.keys()) == ["4"]
+    # Every generated circuit belongs to that single group.
+    assert {num_qubits for num_qubits, _ in circuit_identifiers} == {"4"}
+    assert len(circuits) == len(circuit_identifiers)
+    assert len(circuits) >= 1
+
+
+def test_qft_num_qubits_respects_max_circuits():
+    """num_qubits leaves the per-group circuit count under max_circuits control."""
+    _, circuit_metrics, circuit_identifiers = get_circuits_and_metrics(
+        benchmark_name="Quantum Fourier Transform",
+        params={
+            "num_qubits": 5,
+            "shots": 100,
+            "max_circuits": 1,
+            "method": 1,
+            "use_midcircuit_measurement": False,
+        },
+    )
+
+    assert list(circuit_metrics.keys()) == ["5"]
+    assert len(circuit_identifiers) == 1
+
+
+def test_accuracy_score_does_not_accumulate_across_calls():
+    """Scoring several QED-C jobs in one process must not aggregate across them.
+
+    QED-C's metrics module keeps group statistics in module-global state that
+    aggregate_metrics() appends to. A suite that sweeps QFT over qubit counts
+    polls multiple jobs in a single process, so each score must depend only on
+    its own circuit metrics. Without the reset, the second and third calls would
+    return inflated scores (2.0, 3.0) instead of 1.0.
+    """
+    for num_qubits in ("3", "4", "5"):
+        circuit_metrics = {num_qubits: {str(i): {"fidelity": 1.0} for i in range(3)}}
+        score, uncertainty = calculate_accuracy_score(circuit_metrics)
+        assert score == pytest.approx(1.0)
+        assert uncertainty == pytest.approx(0.0)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -56,10 +56,33 @@ def test_list_jobs_all(capsys):
     assert captured.out == expected_output
 
 
-def test_list_jobs_prefers_max_qubits_for_qft(capsys):
+def test_list_jobs_shows_num_qubits_for_qft(capsys):
     mock_jobs = [
         MetriqGymJob(
             id="qft1",
+            device_name="local_sim",
+            provider_name="local",
+            job_type=JobType.QUANTUM_FOURIER_TRANSFORM,
+            dispatch_time=datetime.fromisoformat("2021-09-01T12:00:00"),
+            params={"num_qubits": 5},
+            data={},
+        )
+    ]
+
+    list_jobs(mock_jobs, show_index=False, show_suite_id=False)
+    captured = capsys.readouterr()
+
+    table = [["qft1", "local", "local_sim", "Quantum Fourier Transform", 5, "2021-09-01T12:00:00"]]
+    expected_output = tabulate(table, headers=LIST_JOBS_HEADERS, tablefmt="grid") + "\n"
+    assert captured.out == expected_output
+
+
+def test_list_jobs_falls_back_to_max_qubits_for_legacy_qft(capsys):
+    # QFT jobs dispatched before the single-qubit-count change persisted a
+    # max_qubits sweep bound; num_qubits() still resolves those via fallback.
+    mock_jobs = [
+        MetriqGymJob(
+            id="qft_legacy",
             device_name="local_sim",
             provider_name="local",
             job_type=JobType.QUANTUM_FOURIER_TRANSFORM,
@@ -72,7 +95,9 @@ def test_list_jobs_prefers_max_qubits_for_qft(capsys):
     list_jobs(mock_jobs, show_index=False, show_suite_id=False)
     captured = capsys.readouterr()
 
-    table = [["qft1", "local", "local_sim", "Quantum Fourier Transform", 6, "2021-09-01T12:00:00"]]
+    table = [
+        ["qft_legacy", "local", "local_sim", "Quantum Fourier Transform", 6, "2021-09-01T12:00:00"]
+    ]
     expected_output = tabulate(table, headers=LIST_JOBS_HEADERS, tablefmt="grid") + "\n"
     assert captured.out == expected_output
 


### PR DESCRIPTION
Part of #776.

## What changed

QFT was the only benchmark taking a min/max/skip qubit range and sweeping internally, which metriq-data does not represent per qubit count.

- The QFT schema now takes a single `num_qubits` instead of `min_qubits`/`max_qubits`/`skip_qubits`, matching the other benchmarks. A fixed `num_qubits` maps to a one-point QED-C sweep in `get_circuits_and_metrics`, so `num_qubits()` reports the QFT qubit count and metriq-data keys results on it.
- New `metriq_gym/suites/qft_sweep.json` dispatches one QFT run per qubit count, so the sweep lives at the suite level rather than inside the benchmark.
- `calculate_accuracy_score` resets the QED-C metrics group accumulator before scoring each job. That state is module-global, so polling several QED-C jobs in one process (a QFT sweep suite, or any suite mixing QED-C benchmarks) previously aggregated each job's fidelities on top of the previous ones and inflated the score. This surfaced while validating the sweep and is fixed here.

## Validation

On the Aer simulator:
- Single QFT run (`num_qubits=5`): accuracy_score 1.0, record carries `num_qubits: 5`.
- `qft_sweep` suite (3, 4, 5 qubits): three separate jobs under one suite id, each scores 1.0 and keeps its own qubit count. Before the accumulation fix these scored 1.0 / 2.0 / 3.0.

## metriq-data side (not in this PR)

Making QFT a single-qubit-count benchmark lets it flow through the existing metriq-data pipeline like the other benchmarks. To show the sweep as distinct points, `scripts/scoring.json` needs the QFT component changed from one selector-less entry to a group of `num_qubits`-selector components, the same pattern QML Kernel already uses (QMLK-10, QMLK-20, ...). I verified against metriq-data's own `_row_param_matches` that each QFT record then matches exactly its own qubit-count component. The specific qubit counts and weights are a scoring-policy choice, so I left that config change out of this PR.