### PR TITLE
Floor LR-QAOA effective_approx_ratio at zero

### DIFF
--- a/metriq_gym/benchmarks/lr_qaoa.py
+++ b/metriq_gym/benchmarks/lr_qaoa.py
@@ -345,8 +345,9 @@ def calc_stats(data: LinearRampQAOAData, samples: list["MeasCount"]) -> Aggregat
         all(stat[ith_layer].confidence_pass for stat in trial_stats)
         for ith_layer in range(len(data.qaoa_layers))
     ]
+    # Floored at zero: performance at or below the random-sampling baseline scores 0.
     effective_approx_ratio = [
-        (r - data.approx_ratio_random_mean) / (1 - data.approx_ratio_random_mean)
+        max(0.0, (r - data.approx_ratio_random_mean) / (1 - data.approx_ratio_random_mean))
         for r in approx_ratio
     ]
 

--- a/tests/unit/benchmarks/test_lr-qaoa.py
+++ b/tests/unit/benchmarks/test_lr-qaoa.py
@@ -142,6 +142,12 @@ def test_calc_stats_pass():
     assert [round(i, 6) for i in stats.optimal_probability] == [0.6, 1.0, 0.25]
     assert [round(i, 6) for i in stats.approx_ratio] == [0.645, 1.0, 0.25]
     assert round(approx_ratio_random_mean, 1) == 0.5
+    # effective_approx_ratio is floored at zero when approx_ratio is below the
+    # random baseline (third layer: 0.25 < ~0.5), and positive otherwise.
+    assert stats.effective_approx_ratio[0] > 0
+    assert stats.effective_approx_ratio[1] == 1.0
+    assert stats.effective_approx_ratio[2] == 0.0
+    assert all(r >= 0 for r in stats.effective_approx_ratio)
 
 
 @pytest.mark.parametrize("width, length", [(5, 5), (7, 7), (3, 3)])


### PR DESCRIPTION
Fixes #785.

`effective_approx_ratio` is computed as `(r - random_mean) / (1 - random_mean)`, which goes negative when the measured approximation ratio falls below the random-sampling baseline, and the negative values propagate into the final score. This floors each entry at zero, so performance at or below random guessing scores 0.

Extended `test_calc_stats_pass` to cover the flooring: the third layer in that test has `approx_ratio = 0.25`, below the ~0.5 random baseline, and now yields exactly 0.
