### PR TITLE
Fix dotenv discovery for installed CLI

### DIFF
--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -7,7 +7,7 @@ import os
 import sys
 import logging
 import uuid
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from tabulate import tabulate
 from typing import Any, TYPE_CHECKING, Optional
@@ -990,7 +990,7 @@ def estimate_job(args: argparse.Namespace, _job_manager: JobManager | None = Non
 
 
 def main() -> int:
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     typer_app()
     return 0
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -12,6 +12,7 @@ from qbraid.runtime import BraketDevice, JobStatus
 from qbraid.runtime.result_data import GateModelResultData, MeasCount
 from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult, BenchmarkScore
 from metriq_gym.run import (
+    main,
     load_provider,
     setup_device,
     validate_benchmark_device_capacity,
@@ -36,6 +37,16 @@ from metriq_gym.resource_estimation import (
 class FakeDevice:
     def __init__(self, id):
         self.id = id
+
+
+def test_main_loads_dotenv_from_working_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MGYM_DOTENV_TEST", raising=False)
+    monkeypatch.setattr("metriq_gym.run.typer_app", lambda: None)
+    (tmp_path / ".env").write_text("MGYM_DOTENV_TEST=loaded\n")
+
+    assert main() == 0
+    assert os.environ["MGYM_DOTENV_TEST"] == "loaded"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- anchor `.env` discovery to the directory where `mgym` is invoked
- search upward from that working directory for a project-level `.env`
- add a regression test covering CLI startup from a separate working directory

Fixes #779

## Testing

- `pytest tests/unit/test_run.py -q` (39 passed)
- `pytest -m 'not e2e' -q` (410 passed, 15 deselected)
- `ruff check metriq_gym/run.py tests/unit/test_run.py`
- `ruff format --check metriq_gym/run.py tests/unit/test_run.py`
- commit hooks: ruff, ruff-format, mypy, deptry