### PR TITLE
Make EPLG long-chain sampling robust on IBM devices

### DIFF
--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -76,6 +76,10 @@ class EPLGResult(BenchmarkResult):
 # =============================================================================
 
 
+# VF2 is a backtracking graph-matching algorithm. Here it looks for a simple
+# path graph inside the device's connectivity graph.
+# Reference:
+# https://networkx.org/documentation/stable/reference/algorithms/isomorphism.vf2.html
 _VF2_SEARCH_ATTEMPTS = 5
 _VF2_CALL_LIMIT = 100_000
 
@@ -85,7 +89,7 @@ def _randomized_graph_copy(
     edges: set[tuple[int, int]],
     rng: random.Random,
 ) -> rx.PyGraph:
-    """Copy a graph with seed-shuffled node IDs for reproducible VF2 search."""
+    """Copy a graph with seed-shuffled node IDs for reproducible fallback search."""
     shuffled_nodes = node_indices.copy()
     rng.shuffle(shuffled_nodes)
 
@@ -109,7 +113,7 @@ def _vf2_random_chain(
     length: int,
     rng: random.Random,
 ) -> list[int] | None:
-    """Find any seeded-random path using bounded VF2 subgraph matching."""
+    """Use the bounded VF2 search described above to find a seeded-random path."""
     path_graph = rx.generators.path_graph(length)
 
     for _ in range(_VF2_SEARCH_ATTEMPTS):
@@ -149,8 +153,9 @@ def random_chain_from_graph(
     """Sample a seeded random simple path of given length from a graph.
 
     The fast greedy search is retained for stable results on topologies where
-    it already succeeds. A bounded VF2 search is used as a fallback when the
-    greedy walk repeatedly traps itself on a graph that still has a valid path.
+    it already succeeds. A bounded graph-matching search is used as a fallback
+    when the greedy walk repeatedly traps itself on a graph that still has a
+    valid path.
 
     Args:
         graph: Connectivity graph (undirected).

--- a/metriq_gym/benchmarks/eplg.py
+++ b/metriq_gym/benchmarks/eplg.py
@@ -76,29 +76,123 @@ class EPLGResult(BenchmarkResult):
 # =============================================================================
 
 
+_VF2_SEARCH_ATTEMPTS = 5
+_VF2_CALL_LIMIT = 100_000
+
+
+def _randomized_graph_copy(
+    node_indices: list[int],
+    edges: set[tuple[int, int]],
+    rng: random.Random,
+) -> rx.PyGraph:
+    """Copy a graph with seed-shuffled node IDs for reproducible VF2 search."""
+    shuffled_nodes = node_indices.copy()
+    rng.shuffle(shuffled_nodes)
+
+    randomized_graph = rx.PyGraph(multigraph=False)
+    randomized_index = {
+        original_index: randomized_graph.add_node(original_index)
+        for original_index in shuffled_nodes
+    }
+
+    shuffled_edges = sorted(edges)
+    rng.shuffle(shuffled_edges)
+    randomized_graph.add_edges_from_no_data(
+        [(randomized_index[source], randomized_index[target]) for source, target in shuffled_edges]
+    )
+    return randomized_graph
+
+
+def _vf2_random_chain(
+    node_indices: list[int],
+    edges: set[tuple[int, int]],
+    length: int,
+    rng: random.Random,
+) -> list[int] | None:
+    """Find any seeded-random path using bounded VF2 subgraph matching."""
+    path_graph = rx.generators.path_graph(length)
+
+    for _ in range(_VF2_SEARCH_ATTEMPTS):
+        randomized_graph = _randomized_graph_copy(node_indices, edges, rng)
+        mapping = next(
+            rx.vf2_mapping(
+                randomized_graph,
+                path_graph,
+                id_order=False,
+                subgraph=True,
+                induced=False,
+                call_limit=_VF2_CALL_LIMIT,
+            ),
+            None,
+        )
+        if mapping is None or len(mapping) != length:
+            continue
+
+        chain = [
+            randomized_graph[graph_index]
+            for graph_index, _ in sorted(mapping.items(), key=lambda item: item[1])
+        ]
+        if len(set(chain)) == length and all(
+            tuple(sorted((source, target))) in edges for source, target in zip(chain, chain[1:])
+        ):
+            return chain
+
+    return None
+
+
 def random_chain_from_graph(
     graph: rx.PyGraph,
     length: int,
     seed: int | None = None,
     restarts: int = 200,
 ) -> list[int]:
-    """Sample a random simple path of given length from a graph.
+    """Sample a seeded random simple path of given length from a graph.
+
+    The fast greedy search is retained for stable results on topologies where
+    it already succeeds. A bounded VF2 search is used as a fallback when the
+    greedy walk repeatedly traps itself on a graph that still has a valid path.
 
     Args:
         graph: Connectivity graph (undirected).
         length: Desired chain length (number of nodes).
         seed: Random seed.
-        restarts: Number of random restart attempts.
+        restarts: Number of greedy random restart attempts before the bounded fallback.
 
     Returns:
         List of qubit indices forming the chain.
     """
+    if length < 1:
+        raise ValueError(f"Chain length must be positive; received {length}.")
+    if restarts < 0:
+        raise ValueError(f"Restarts must be non-negative; received {restarts}.")
+
     rng = random.Random(seed)
 
-    allowed = {tuple(sorted(e)) for e in graph.edge_list()}
+    allowed: set[tuple[int, int]] = {
+        (min(source, target), max(source, target))
+        for source, target in graph.edge_list()
+        if source != target
+    }
+    node_indices = sorted(graph.node_indices())
+    n_nodes = len(node_indices)
 
-    n_nodes = graph.num_nodes()
-    adj: dict[int, list[int]] = {i: [] for i in range(n_nodes)}
+    if length > n_nodes:
+        raise ValueError(
+            f"Cannot sample a chain of length={length}: the connectivity graph "
+            f"has only {n_nodes} nodes."
+        )
+    if length == 1:
+        return [rng.choice(node_indices)]
+
+    largest_component = max((len(component) for component in rx.connected_components(graph)))
+    if largest_component < length:
+        raise ValueError(
+            f"Cannot sample a chain of length={length}: the largest connected component "
+            f"has only {largest_component} nodes (graph: {n_nodes} nodes, "
+            f"{len(allowed)} edges)."
+        )
+
+    adj: dict[int, list[int]] = {node_index: [] for node_index in node_indices}
     for u, v in allowed:
         adj[u].append(v)
         adj[v].append(u)
@@ -137,7 +231,18 @@ def random_chain_from_graph(
         if len(path) == length:
             return path
 
-    raise RuntimeError(f"Failed to sample chain of length={length} after {restarts} restarts.")
+    fallback_chain = _vf2_random_chain(node_indices, allowed, length, rng)
+    if fallback_chain is not None:
+        return fallback_chain
+
+    raise RuntimeError(
+        f"Could not find a simple chain of length={length} in a graph with {n_nodes} nodes "
+        f"and {len(allowed)} edges after {restarts} greedy restarts and "
+        f"{_VF2_SEARCH_ATTEMPTS} bounded path-search attempts "
+        f"({_VF2_CALL_LIMIT} states each). A sufficiently long path may not exist, or the "
+        "search budget may have been exhausted; try a shorter chain or inspect the "
+        "gate-specific connectivity graph."
+    )
 
 
 # =============================================================================

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -73,9 +73,9 @@ class BaseExporter(ABC):
 
         record["platform"] = platform_info
 
-        # Surface per-circuit two-qubit gate counts collected at dispatch time.
-        # These live on the BenchmarkData (stored as the job's ``data`` dict) and
-        # are emitted additively so existing fields are unaffected.
+        # Surface circuit metadata collected at dispatch time. These values live
+        # on BenchmarkData (stored as the job's ``data`` dict) and are emitted
+        # additively so existing fields are unaffected.
         job_data = getattr(self.metriq_gym_job, "data", None)
         if isinstance(job_data, dict):
             circuit_metadata = {
@@ -83,6 +83,7 @@ class BaseExporter(ABC):
                 for key in (
                     "input_two_qubit_gate_counts",
                     "transpiled_two_qubit_gate_counts",
+                    "qubit_chain",
                 )
                 if job_data.get(key) is not None
             }

--- a/tests/unit/benchmarks/test_eplg.py
+++ b/tests/unit/benchmarks/test_eplg.py
@@ -24,13 +24,12 @@ def test_random_chain_from_graph_path():
     """Test random chain from path graph."""
     graph = rx.generators.path_graph(10)
     with patch("metriq_gym.benchmarks.eplg.rx.vf2_mapping") as vf2_mapping:
-        chain = random_chain_from_graph(graph, 5, seed=42)
+        first = random_chain_from_graph(graph, 5, seed=42)
+        second = random_chain_from_graph(graph, 5, seed=42)
 
-    assert chain == [0, 1, 2, 3, 4]
+    assert first == second
+    assert_valid_chain(graph, first, 5)
     vf2_mapping.assert_not_called()
-    # Verify it's a valid path
-    for i in range(len(chain) - 1):
-        assert graph.has_edge(chain[i], chain[i + 1])
 
 
 def test_random_chain_from_graph_complete():

--- a/tests/unit/benchmarks/test_eplg.py
+++ b/tests/unit/benchmarks/test_eplg.py
@@ -4,20 +4,30 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import rustworkx as rx
+from qiskit_ibm_runtime.fake_provider import FakeMarrakesh
 
 from metriq_gym.benchmarks.eplg import (
     EPLG,
     random_chain_from_graph,
 )
+from metriq_gym.qplatform.device import coupling_map_to_graph
+
+
+def assert_valid_chain(graph: rx.PyGraph, chain: list[int], length: int) -> None:
+    """Assert that a chain is simple, has the requested size, and follows graph edges."""
+    assert len(chain) == length
+    assert len(set(chain)) == length
+    assert all(graph.has_edge(source, target) for source, target in zip(chain, chain[1:]))
 
 
 def test_random_chain_from_graph_path():
     """Test random chain from path graph."""
     graph = rx.generators.path_graph(10)
-    chain = random_chain_from_graph(graph, 5, seed=42)
+    with patch("metriq_gym.benchmarks.eplg.rx.vf2_mapping") as vf2_mapping:
+        chain = random_chain_from_graph(graph, 5, seed=42)
 
-    assert len(chain) == 5
-    assert len(set(chain)) == 5
+    assert chain == [0, 1, 2, 3, 4]
+    vf2_mapping.assert_not_called()
     # Verify it's a valid path
     for i in range(len(chain) - 1):
         assert graph.has_edge(chain[i], chain[i + 1])
@@ -30,6 +40,66 @@ def test_random_chain_from_graph_complete():
 
     assert len(chain) == 5
     assert len(set(chain)) == 5
+
+
+def test_random_chain_from_graph_falls_back_for_marrakesh():
+    """A valid Marrakesh 100-chain is found after the greedy search gets trapped."""
+    backend = FakeMarrakesh()
+    graph = coupling_map_to_graph(backend.target.build_coupling_map(two_q_gate="cz"))
+
+    chain = random_chain_from_graph(graph, 100, seed=12345)
+
+    assert_valid_chain(graph, chain, 100)
+
+
+def test_random_chain_vf2_fallback_is_seeded_and_deterministic():
+    """The fallback handles a Miami-like grid reproducibly without greedy attempts."""
+    graph = rx.generators.grid_graph(10, 12)
+
+    first = random_chain_from_graph(graph, 100, seed=12345, restarts=0)
+    second = random_chain_from_graph(graph, 100, seed=12345, restarts=0)
+
+    assert first == second
+    assert_valid_chain(graph, first, 100)
+
+
+def test_random_chain_from_graph_supports_non_contiguous_node_indices():
+    """Removed graph nodes do not break adjacency or fallback mapping."""
+    graph = rx.PyGraph()
+    graph.add_nodes_from([None] * 7)
+    graph.add_edges_from_no_data([(0, 2), (2, 4), (4, 6)])
+    graph.remove_nodes_from([1, 3, 5])
+
+    chain = random_chain_from_graph(graph, 4, seed=12345, restarts=0)
+
+    assert_valid_chain(graph, chain, 4)
+    assert set(chain) == {0, 2, 4, 6}
+
+
+def test_random_chain_rejects_insufficient_connectivity():
+    """Definitively incompatible component sizes produce an actionable error."""
+    graph = rx.PyGraph()
+    graph.add_nodes_from([None] * 8)
+    graph.add_edges_from_no_data([(0, 1), (1, 2), (2, 3), (4, 5), (5, 6), (6, 7)])
+
+    with pytest.raises(ValueError, match="largest connected component has only 4 nodes"):
+        random_chain_from_graph(graph, 5, seed=12345)
+
+
+def test_random_chain_rejects_more_nodes_than_the_graph_contains():
+    """A request larger than the entire graph fails before searching."""
+    graph = rx.generators.path_graph(4)
+
+    with pytest.raises(ValueError, match="connectivity graph has only 4 nodes"):
+        random_chain_from_graph(graph, 5, seed=12345)
+
+
+def test_random_chain_reports_inconclusive_bounded_search():
+    """A large component without a long simple path is not called incompatible."""
+    graph = rx.generators.star_graph(10)
+
+    with pytest.raises(RuntimeError, match="search budget may have been exhausted"):
+        random_chain_from_graph(graph, 5, seed=12345, restarts=0)
 
 
 def test_eplg_warns_when_device_gate_support_cannot_be_confirmed():

--- a/tests/unit/benchmarks/test_gate_counts.py
+++ b/tests/unit/benchmarks/test_gate_counts.py
@@ -192,10 +192,10 @@ class _DummyResult(BenchmarkResult):
 
 
 class TestExporterSurfacesCounts:
-    def _job(self, data: dict) -> MetriqGymJob:
+    def _job(self, data: dict, job_type: JobType = JobType.CLOPS) -> MetriqGymJob:
         return MetriqGymJob(
             id="job",
-            job_type=JobType.CLOPS,
+            job_type=job_type,
             params={"shots": 10},
             data=data,
             provider_name="provider",
@@ -217,8 +217,16 @@ class TestExporterSurfacesCounts:
             "transpiled_two_qubit_gate_counts": [4, 4],
         }
 
+    def test_qubit_chain_present_in_export(self):
+        job = self._job(
+            {"provider_job_ids": ["q"], "qubit_chain": [2, 4, 6]},
+            job_type=JobType.EPLG,
+        )
+        record = DictExporter(job, _DummyResult(metric=1.0)).export()
+        assert record["circuit_metadata"] == {"qubit_chain": [2, 4, 6]}
+
     def test_no_circuit_metadata_when_absent(self):
-        # Backward compatibility: records without the counts emit no new block.
+        # Backward compatibility: records without supported metadata emit no new block.
         job = self._job({"provider_job_ids": ["q"]})
         record = DictExporter(job, _DummyResult(metric=1.0)).export()
         assert "circuit_metadata" not in record


### PR DESCRIPTION
Closes #800.

The 100-qubit EPLG component was failing before dispatch on IBM Marrakesh and Miami with:

> Failed to sample chain of length=100 after 200 restarts.

Those devices do have suitable chains. The failure came from the search strategy: the sampler used greedy random walks without backtracking, so a long walk could repeatedly paint itself into a corner. Reaching the restart limit therefore looked like a device constraint even when a valid path existed.

This keeps the current greedy sampler as the fast path, including its existing seeded behavior wherever it already succeeds. If those walks all get stuck, it falls back to a small number of bounded VF2 path searches over seeded, shuffled copies of the connectivity graph.

The important bit is that this still finds **a** random, reproducible, topology-compatible chain. It does not use calibration data or select the “best” chain. Choosing an optimal chain would change the semantics of the Metriq Score 1.0 EPLG benchmark; this change only makes the existing random-chain strategy more reliable.

It also makes the failure modes more useful:

- requests larger than the graph, or its largest connected component, fail early with a concrete explanation;
- an exhausted bounded search says that either no suitable path exists or the search budget ran out, rather than claiming incompatibility;
- graphs with non-contiguous qubit indices are handled correctly.

The selected `qubit_chain` is also included in exported circuit metadata, so the exact chain used by a run is available for inspection and reproducibility. This is additive and leaves older jobs unchanged.

### Validation

- Regression on the CZ topology from `FakeMarrakesh`, requesting 100 qubits with the suite seed
- Forced, deterministic fallback on a Miami-like 10×12 topology
- Coverage for non-contiguous node indices and the new error paths
- Exporter coverage for `qubit_chain`
- Full test suite: 423 passed
- Ruff and mypy passed
- Manual check: the original EPLG workflow successfully reached dispatch on `ibm_miami`